### PR TITLE
housekeeping: add leftook and rust-toolchain

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true  # 🚀 Run commands in parallel for speed
+  commands:
+    fmt:
+      glob: "*.rs"
+      run: cargo fmt --all -- --check
+      stage_fixed: true  # Auto-stage fixed files
+    
+    clippy:
+      glob: "*.rs" 
+      run: cargo clippy --all-targets --all-features -- -D warnings

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
These files are used to ensure consistent formatting and linting