### PR TITLE
Include git hash in binary output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "faux-rtos"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 socket2 = "0.5.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    let git_hash = git_hash.trim();
+
+    let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("git_hash.rs");
+    let mut f = File::create(&dest_path).unwrap();
+
+    write!(f, "pub const GIT_HASH: &str = \"{}\";\n", git_hash).unwrap();
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ pub mod telemetry;
 pub mod keyboard;
 pub mod policy_control;
 
+pub mod git_hash {
+    include!(concat!(env!("OUT_DIR"), "/git_hash.rs"));
+}
+
 use std::task::{Context, Poll};
 
 use crate::robstride::{
@@ -129,6 +133,7 @@ fn main() {
     let guard = tracing::subscriber::set_default(subscriber);
     
     let start_time = std::time::Instant::now();
+    info!("Starting faux-rtos version: {}", git_hash::GIT_HASH);
     info!("id: {:?} starting at {:?}", std::thread::current().id(), start_time);
     
     // Create runtime


### PR DESCRIPTION
Embed a git hash in the executable at build time, for traceability on what version of the code generated a given binary.