### PR TITLE
clippy: fix all errors and warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 fn main() {
     let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
@@ -15,7 +15,7 @@ fn main() {
     let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("git_hash.rs");
     let mut f = File::create(&dest_path).unwrap();
 
-    write!(f, "pub const GIT_HASH: &str = \"{}\";\n", git_hash).unwrap();
+    writeln!(f, "pub const GIT_HASH: &str = \"{git_hash}\";").unwrap();
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/index");
     println!("cargo:rerun-if-changed=build.rs");

--- a/src/actuator.rs
+++ b/src/actuator.rs
@@ -79,6 +79,7 @@ impl Operate {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -105,6 +106,7 @@ impl State for Reset {
 }
 
 impl State for Ready {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             StateTransitionResult {
@@ -118,6 +120,7 @@ impl State for Ready {
 }
 
 impl State for Configure {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             if let Err(e) =
@@ -159,6 +162,7 @@ impl State for Configure {
 }
 
 impl State for Operate {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let shared_state = self.shared_state;
@@ -174,14 +178,11 @@ async fn send_commands(ss: Pin<&mut Store>, act_states: &[ActuatorState]) -> std
     let mut ss = ss.project();
     let Some(SocketState::Operate(op_socket)) = ss.socket_graph.project().state else {
         // no operational socket, go back to configure state
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Socket is not in Operate state",
-        ));
+        return Err(std::io::Error::other("Socket is not in Operate state"));
     };
 
     for (i, client) in ss.actuator_clients.iter_mut().enumerate() {
-        let params = ActuatorRequestParams::Control(act_states[i].command.clone());
+        let params = ActuatorRequestParams::Control(act_states[i].command);
 
         let req = client.stage_request(&params);
         let res = op_socket.write(&req.into()).await;
@@ -201,10 +202,7 @@ async fn send_request(ss: Pin<&mut Store>, params: &ActuatorRequestParams) -> st
     let mut ss = ss.project();
     let Some(SocketState::Operate(op_socket)) = ss.socket_graph.project().state else {
         // no operational socket, go back to configure state
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Socket is not in Operate state",
-        ));
+        return Err(std::io::Error::other("Socket is not in Operate state"));
     };
 
     for client in ss.actuator_clients.iter_mut() {
@@ -234,18 +232,15 @@ async fn read_responses_update(
 
     let Some(SocketState::Operate(op_socket)) = ss.socket_graph.project().state else {
         // no operational socket, go back to configure state
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Socket is not in Operate state",
-        ));
+        return Err(std::io::Error::other("Socket is not in Operate state"));
     };
 
     let mut n = ss.actuator_clients.len();
 
     let mut handler = |can_frame: &CanFrame| {
-        let client_idx = (ss.response_to_client_idx)(&can_frame);
+        let client_idx = (ss.response_to_client_idx)(can_frame);
         if let Some(client) = ss.actuator_clients.get_mut(client_idx) {
-            match client.handle_response(&can_frame) {
+            match client.handle_response(can_frame) {
                 Ok(Some(fdbk)) => {
                     if let Some(ref mut act_states) = act_states {
                         if let Some(state) = act_states.get_mut(client_idx) {
@@ -253,10 +248,7 @@ async fn read_responses_update(
                         } else {
                             return Err(std::io::Error::new(
                                 std::io::ErrorKind::NotFound,
-                                format!(
-                                    "No ActuatorFeedback found for client index {}",
-                                    client_idx
-                                ),
+                                format!("No ActuatorFeedback found for client index {client_idx}"),
                             ));
                         }
                     }
@@ -269,7 +261,7 @@ async fn read_responses_update(
         } else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("No client found for response with index {}", client_idx),
+                format!("No client found for response with index {client_idx}"),
             ));
         }
         Ok(())
@@ -302,7 +294,7 @@ async fn read_responses_update(
     }
 
     // drain the buffer
-    while let Ok(_) = op_socket.try_read(&mut read_data) {
+    while op_socket.try_read(&mut read_data).is_ok() {
         // Process the read data here
         let can_frame: CanFrame = unsafe { std::mem::transmute(read_data) };
         let client_idx = (ss.response_to_client_idx)(&can_frame);
@@ -329,10 +321,7 @@ impl Store {
     pub fn new(ifname: &str, ids: Vec<ActuatorId>) -> Self {
         Self {
             ifname: ifname.to_string(),
-            actuator_clients: ids
-                .into_iter()
-                .map(|id| ActuatorCanClient::new(id))
-                .collect(),
+            actuator_clients: ids.into_iter().map(ActuatorCanClient::new).collect(),
             response_to_client_idx: |frame: &CanFrame| {
                 let id = actuator_can_id_from_response(frame);
                 ((id % 10) - 1) as usize

--- a/src/actuator_manager.rs
+++ b/src/actuator_manager.rs
@@ -53,6 +53,12 @@ pub struct Store {
     av_iface_idxs: std::collections::VecDeque<usize>,
 }
 
+impl Default for Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Store {
     pub fn new() -> Self {
         let iface_names = ["can0", "can1", "can2", "can3", "can4"].map(String::from);
@@ -127,10 +133,7 @@ impl Ready {
                 // enable the bus
                 rdy_bus.enable().await?;
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Bus is not in Operate state",
-                ));
+                return Err(io::Error::other("Bus is not in Operate state"));
             }
         }
         Ok(())
@@ -138,6 +141,7 @@ impl Ready {
 }
 
 impl State for Ready {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -180,10 +184,7 @@ impl State for Ready {
                     Ok(None) => {
                         return StateTransitionResult {
                             state: StateStore::Reset(Reset { shared_state }),
-                            result: Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                "No data received from bus",
-                            )),
+                            result: Err(io::Error::other("No data received from bus")),
                         };
                     }
                     Err(e) => {
@@ -211,6 +212,7 @@ impl State for Ready {
 }
 
 impl State for Scanning {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -254,10 +256,7 @@ impl State for Scanning {
                     Ok(None) => {
                         return StateTransitionResult {
                             state: StateStore::Reset(Reset { shared_state }),
-                            result: Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                "No data received from bus",
-                            )),
+                            result: Err(io::Error::other("No data received from bus")),
                         };
                     }
                     Err(e) => {
@@ -294,6 +293,7 @@ impl State for Scanning {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -316,10 +316,7 @@ impl Operate {
                 // enable the bus
                 op_bus.request_feedback().await?;
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Bus is not in Operate state",
-                ));
+                return Err(io::Error::other("Bus is not in Operate state"));
             }
         }
         Ok(())
@@ -340,10 +337,7 @@ impl Operate {
                     .process_feedback(act_states.slice_mut(i.into()))
                     .await?;
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Bus is not in Operate state",
-                ));
+                return Err(io::Error::other("Bus is not in Operate state"));
             }
         }
         Ok(())
@@ -359,10 +353,7 @@ impl Operate {
                 // enable the bus
                 op_bus.command(act_states.slice(BusTag::from(i))).await?;
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Bus is not in Operate state",
-                ));
+                return Err(io::Error::other("Bus is not in Operate state"));
             }
         }
         Ok(())
@@ -436,6 +427,7 @@ impl Operate {
 }
 
 impl State for Operate {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -466,6 +458,12 @@ pub struct ActuatorManager {
     pending_fut: Option<StateFut>,
 }
 
+impl Default for ActuatorManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ActuatorManager {
     pub fn new() -> Self {
         Self {
@@ -487,7 +485,7 @@ impl ActuatorManager {
 
     pub fn reset_state(&mut self) -> std::io::Result<()> {
         if self.state.is_none() {
-            return Err(io::Error::new(io::ErrorKind::Other, "No state to reset"));
+            return Err(io::Error::other("No state to reset"));
         }
 
         self.state = Some(match self.state.take().unwrap() {

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -37,6 +37,12 @@ pub struct Store {
     kb_manager: crate::keyboard::KeyboardManager,
 }
 
+impl Default for Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Store {
     pub fn new() -> Self {
         let robot_description = RobotDescription::new();
@@ -55,23 +61,23 @@ impl Store {
 }
 
 #[derive(Debug)]
-struct Reset {
+pub struct Reset {
     shared_state: Pin<Box<Store>>,
 }
 
 #[derive(Debug)]
-struct Ready {
+pub struct Ready {
     shared_state: Pin<Box<Store>>,
 }
 
 #[derive(Debug)]
-struct Home {
+pub struct Home {
     shared_state: Pin<Box<Store>>,
     start: std::time::Instant,
 }
 
 #[derive(Debug)]
-struct Policy {
+pub struct Policy {
     shared_state: Pin<Box<Store>>,
 }
 
@@ -119,6 +125,7 @@ impl Home {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -131,6 +138,7 @@ impl State for Reset {
 }
 
 impl State for Ready {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -171,10 +179,7 @@ impl State for Ready {
             else {
                 return StateTransitionResult {
                     state: StateStore::Reset(Reset { shared_state }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "IMU manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("IMU manager is not in Operate state")),
                 };
             };
             op_imu_manager
@@ -221,10 +226,7 @@ impl State for Ready {
             else {
                 return StateTransitionResult {
                     state: StateStore::Reset(Reset { shared_state }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Actuator manager is not in Ready state",
-                    )),
+                    result: Err(io::Error::other("Actuator manager is not in Ready state")),
                 };
             };
 
@@ -265,10 +267,7 @@ impl State for Ready {
             else {
                 return StateTransitionResult {
                     state: StateStore::Reset(Reset { shared_state }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Model manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("Model manager is not in Operate state")),
                 };
             };
 
@@ -276,15 +275,16 @@ impl State for Ready {
             ss.kb_manager.wait_for_enter().await;
 
             rdy_act_manager.enable().await;
-            return StateTransitionResult {
+            StateTransitionResult {
                 state: StateStore::Home(Home::new(shared_state)),
                 result: Ok(()),
-            };
+            }
         }
     }
 }
 
 impl State for Home {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = &mut self.shared_state;
@@ -330,10 +330,7 @@ impl State for Home {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Actuator manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("Actuator manager is not in Operate state")),
                 };
             };
 
@@ -347,10 +344,7 @@ impl State for Home {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "IMU manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("IMU manager is not in Operate state")),
                 };
             };
 
@@ -375,7 +369,7 @@ impl State for Home {
                 .await;
             // run controller
 
-            let err = Self::step_controller(&mut ss.robot_description);
+            let err = Self::step_controller(ss.robot_description);
             // TODO
             // get time since start
 
@@ -413,7 +407,7 @@ impl State for Home {
                 op_imu_manager
                     .process_feedback(&mut ss.robot_description.imu)
                     .await;
-                ss.robot_description.initial_imu = ss.robot_description.imu.clone();
+                ss.robot_description.initial_imu = ss.robot_description.imu;
                 ss.kb_manager.wait_for_enter().await;
 
                 return StateTransitionResult {
@@ -424,18 +418,19 @@ impl State for Home {
                 };
             }
 
-            return StateTransitionResult {
+            StateTransitionResult {
                 state: StateStore::Home(Home {
                     shared_state: self.shared_state,
                     start: self.start, // keep the start time to continue the sine wave
                 }),
                 result: Ok(()),
-            };
+            }
         }
     }
 }
 
 impl State for Policy {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = &mut self.shared_state;
@@ -458,10 +453,7 @@ impl State for Policy {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Actuator manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("Actuator manager is not in Operate state")),
                 };
             };
 
@@ -475,10 +467,7 @@ impl State for Policy {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "IMU manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("IMU manager is not in Operate state")),
                 };
             };
 
@@ -518,16 +507,13 @@ impl State for Policy {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Model manager is not in Operate state",
-                    )),
+                    result: Err(io::Error::other("Model manager is not in Operate state")),
                 };
             };
 
             warn!("Reading took {:?}", start_time.elapsed());
             let policy_stamp = std::time::Instant::now();
-            op_model.step_controller(&mut ss.robot_description);
+            op_model.step_controller(ss.robot_description);
             warn!("Policy step took {:?}", policy_stamp.elapsed());
 
             // print out the commands
@@ -580,6 +566,12 @@ pub struct BehaviorManager {
 
     #[pin]
     pending_fut: Option<StateFut>,
+}
+
+impl Default for BehaviorManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl BehaviorManager {

--- a/src/hiwonder.rs
+++ b/src/hiwonder.rs
@@ -136,12 +136,12 @@ impl HiwonderImu {
     }
 
     fn merge_frame(frame: &HiwonderRawFrame, fdbk: &mut ImuFeedback) -> io::Result<()> {
-        let frame = frame.clone().try_into()?;
+        let frame = (*frame).try_into()?;
         debug!("Parsed frame: {:?}", frame);
         match frame {
             ReadFrame::Acceleration { x, y, z, temp } => {
                 fdbk.accelerometer = Some([x.into(), y.into(), z.into()]);
-                fdbk.temperature = Some(temp.into());
+                fdbk.temperature = Some(temp);
             }
             ReadFrame::Gyro { x, y, z, voltage } => {
                 fdbk.gyroscope = Some([x.into(), y.into(), z.into()]);
@@ -159,7 +159,7 @@ impl HiwonderImu {
             }
             ReadFrame::Magnetometer { x, y, z, temp } => {
                 fdbk.magnetometer = Some([x.into(), y.into(), z.into()]);
-                fdbk.temperature = Some(temp.into());
+                fdbk.temperature = Some(temp);
             }
             _ => {
                 return Err(io::Error::new(
@@ -329,7 +329,7 @@ impl TryFrom<u8> for FrameType {
             0x5F => Ok(FrameType::GenericRead),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Unknown frame type byte: {:#02x}", value),
+                format!("Unknown frame type byte: {value:#02x}"),
             )),
         }
     }
@@ -577,7 +577,7 @@ pub enum FusionAlgorithm {
 #[enumflags2::bitflags]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-enum OutputType {
+pub enum OutputType {
     Time = 1 << 0,
     Acc = 1 << 1,
     Gyro = 1 << 2,

--- a/src/imu.rs
+++ b/src/imu.rs
@@ -59,6 +59,7 @@ pub struct Operate {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             *self.shared_state.as_mut().project().cur_idx = 0;
@@ -89,7 +90,7 @@ impl Scanning {
                     "Read {:?} from IMU",
                     buf128
                         .iter()
-                        .map(|b| format!("{:02x}", b))
+                        .map(|b| format!("{b:02x}"))
                         .collect::<Vec<_>>()
                 );
             }
@@ -111,6 +112,7 @@ impl Scanning {
 }
 
 impl State for Scanning {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = &mut self.shared_state;
@@ -153,10 +155,7 @@ impl State for Scanning {
                     state: StateStore::Reset(Reset {
                         shared_state: self.shared_state,
                     }),
-                    result: Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "serial port is not in Operate state",
-                    )),
+                    result: Err(std::io::Error::other("serial port is not in Operate state")),
                 };
             };
 
@@ -236,10 +235,7 @@ impl Operate {
             .get_state_pinned()
             .expect("serial port should be in Operate state")
         else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "serial port is not in Operate state",
-            ));
+            return Err(std::io::Error::other("serial port is not in Operate state"));
         };
 
         let fdbk = HiwonderImu::parse_all(op_port).await?;
@@ -250,6 +246,7 @@ impl Operate {
 }
 
 impl State for Operate {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             StateTransitionResult {
@@ -268,6 +265,12 @@ pub struct ImuManager {
     target: Option<StateTag>,
     #[pin]
     pending_fut: Option<StateFut>,
+}
+
+impl Default for ImuManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ImuManager {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2,7 +2,7 @@ use crate::robot_description::{self, ActuatorId, RobotDescription};
 use serde::Serialize;
 use tracing::{debug, error, info, trace, warn};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct PolicyStepDescriptor {
     pub step_id: Option<u64>,
     pub t_us: Option<u64>,
@@ -15,24 +15,6 @@ pub struct PolicyStepDescriptor {
     pub gyro: Option<Vec<f32>>,
     pub command: Option<Vec<f32>>,
     pub output: Option<Vec<f32>>,
-}
-
-impl Default for PolicyStepDescriptor {
-    fn default() -> Self {
-        Self {
-            step_id: None,
-            t_us: None,
-            joint_angles: None,
-            joint_vels: None,
-            initial_heading: None,
-            quaternion: None,
-            projected_g: None,
-            accel: None,
-            gyro: None,
-            command: None,
-            output: None,
-        }
-    }
 }
 
 impl PolicyStepDescriptor {
@@ -87,9 +69,9 @@ impl PolicyStepDescriptor {
     pub fn fill_outputs(&mut self, outputs: &ort::session::SessionOutputs) -> std::io::Result<()> {
         let commands = outputs[0]
             .try_extract_array::<f32>()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+            .map_err(std::io::Error::other)?
             .into_dimensionality::<ndarray::Dim<[usize; 1]>>()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         let dst = self.output.as_mut().unwrap();
         dst.iter_mut().zip(commands.iter()).for_each(|(d, s)| {
@@ -123,14 +105,11 @@ impl PolicyStepDescriptor {
         input_val: &ort::session::SessionInputValue,
     ) -> std::io::Result<()> {
         let ort::session::SessionInputValue::Owned(src) = input_val else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Expected Owned tensor",
-            ));
+            return Err(std::io::Error::other("Expected Owned tensor"));
         };
         let mut src = src
             .try_extract_array::<f32>()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         // copy into the appropriate field
         match input_type {
@@ -224,10 +203,9 @@ impl TryFrom<&ort::session::Input> for DataType {
             "accelerometer" => Ok(DataType::Accelerometer),
             "gyroscope" => Ok(DataType::Gyroscope),
             "time" => Ok(DataType::Time),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Unknown data type: {:?}", input),
-            )),
+            _ => Err(std::io::Error::other(format!(
+                "Unknown data type: {input:?}"
+            ))),
         }
     }
 }
@@ -246,16 +224,14 @@ impl TryFrom<&ort::session::Input> for ModelInputType {
             "carry" => Ok(ModelInputType::Carry),
             "command" => {
                 if input.input_type.tensor_shape().is_none() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    return Err(std::io::Error::other(
                         "Command input must have a tensor shape",
                     ));
                 }
 
                 let dims = input.input_type.tensor_shape().unwrap();
                 if dims.len() != 1 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    return Err(std::io::Error::other(
                         "Command input must have a 1D tensor shape",
                     ));
                 }
@@ -333,15 +309,13 @@ impl Store {
                 match model_input_type {
                     ModelInputType::DataType(data_type) => {
                         let target =
-                            ort::tensor::Shape::try_from(robot_description.dimensions(data_type))
-                                .expect("step_fn input should have a tensor shape");
+                            ort::tensor::Shape::from(robot_description.dimensions(data_type));
 
                         if *dims != target {
                             return Err(Error::new(
                                 std::io::ErrorKind::InvalidInput,
                                 format!(
-                                    "step_fn input {} shape ({:?}) does not match robot description ({:?})",
-                                    name, dims, target
+                                    "step_fn input {name} shape ({dims:?}) does not match robot description ({target:?})"
                                 ),
                             ));
                         }
@@ -358,7 +332,7 @@ impl Store {
             } else {
                 return Err(Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    format!("step_fn input {} is not a valid data type", name),
+                    format!("step_fn input {name} is not a valid data type"),
                 ));
             }
         }
@@ -377,17 +351,15 @@ impl Store {
             .output_type
             .tensor_shape()
             .expect("step_fn input should have a tensor shape");
-        let target = ort::tensor::Shape::try_from(
+        let target = ort::tensor::Shape::from(
             robot_description.dimensions(robot_description::DataType::JointAngles),
-        )
-        .expect("step_fn output should have a tensor shape");
+        );
 
         if *dims != target {
             return Err(Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!(
-                    "step_fn output[0] ({}) shape ({:?}) does not match robot description ({:?})",
-                    name, dims, target
+                    "step_fn output[0] ({name}) shape ({dims:?}) does not match robot description ({target:?})"
                 ),
             ));
         }
@@ -452,7 +424,7 @@ impl Store {
                 "metadata.json" => {
                     let mut contents = String::new();
                     entry.read_to_string(&mut contents)?;
-                    log::info!("Loaded metadata: {}", contents);
+                    log::info!("Loaded metadata: {contents}");
                     _metadata = Some(contents);
                 }
                 "init_fn.onnx" => {
@@ -474,18 +446,18 @@ impl Store {
 
         use std::io::{Error, ErrorKind};
         let mut init_session = Session::builder()
-            .map_err(|e| Error::new(ErrorKind::Other, e))?
+            .map_err(Error::other)?
             .commit_from_memory(&init_fn.ok_or_else(|| {
                 Error::new(ErrorKind::NotFound, "init_fn.onnx not found in archive")
             })?)
-            .map_err(|e| Error::new(ErrorKind::Other, e))?;
+            .map_err(Error::other)?;
 
         let step_session = Session::builder()
-            .map_err(|e| Error::new(ErrorKind::Other, e))?
+            .map_err(Error::other)?
             .commit_from_memory(&step_fn.ok_or_else(|| {
                 Error::new(ErrorKind::NotFound, "step_fn.onnx not found in archive")
             })?)
-            .map_err(|e| Error::new(ErrorKind::Other, e))?;
+            .map_err(Error::other)?;
 
         Self::validate_sessions(&init_session, &step_session, robot_description)?;
 
@@ -522,17 +494,17 @@ impl Store {
                 };
                 let mut dst = dst
                     .try_extract_array_mut::<f32>()
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(std::io::Error::other)?;
 
                 // get the carry state
                 let input_values: Vec<(String, ort::value::Value)> = Vec::new();
                 let outputs = init_session
                     .run(input_values)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(std::io::Error::other)?;
 
                 let src = outputs[0]
                     .try_extract_array::<f32>()
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(std::io::Error::other)?;
 
                 ndarray::Zip::from(src.view())
                     .and(dst.view_mut())
@@ -568,11 +540,10 @@ impl Store {
         ];
 
         let actuator_id_to_cmd_idx = enum_map::EnumMap::from_fn(|actuator_id| {
-            let idx = cmd_idx_to_actuator_id
+            cmd_idx_to_actuator_id
                 .iter()
                 .position(|id| *id == actuator_id)
-                .unwrap();
-            idx
+                .unwrap()
         });
 
         Ok(Self {
@@ -602,6 +573,7 @@ impl std::fmt::Debug for Reset {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;
@@ -661,8 +633,7 @@ impl Operate {
 
                     // set the command input to zero
                     let ort::session::SessionInputValue::Owned(arr) = input_val else {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
+                        return Err(std::io::Error::other(
                             "Expected a mutable reference to a DynTensor",
                         ));
                     };
@@ -695,54 +666,48 @@ impl Operate {
         }
 
         let inputs = step_input_vec.as_slice();
-        let outputs = step_session
-            .run(inputs)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let outputs = step_session.run(inputs).map_err(std::io::Error::other)?;
 
         step_description
             .fill_outputs(&outputs)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         // put the carry output back into the input
         for (input_type, input_val) in step_input_types.iter().zip(step_input_vec.iter_mut()) {
             step_description
                 .fill_input(input_type, input_val)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
 
-            match input_type {
-                ModelInputType::Carry => {
-                    let ort::session::SessionInputValue::Owned(dst) = input_val else {
-                        panic!("Expected a mutable reference to a DynTensor");
-                    };
-                    let mut dst = dst
-                        .try_extract_array_mut::<f32>()
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            if let ModelInputType::Carry = input_type {
+                let ort::session::SessionInputValue::Owned(dst) = input_val else {
+                    panic!("Expected a mutable reference to a DynTensor");
+                };
+                let mut dst = dst
+                    .try_extract_array_mut::<f32>()
+                    .map_err(std::io::Error::other)?;
 
-                    let src = outputs[1]
-                        .try_extract_array::<f32>()
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                let src = outputs[1]
+                    .try_extract_array::<f32>()
+                    .map_err(std::io::Error::other)?;
 
-                    ndarray::Zip::from(src.view())
-                        .and(dst.view_mut())
-                        .for_each(|srcp, dstp| {
-                            *dstp = *srcp;
-                        });
-                }
-                _ => {}
+                ndarray::Zip::from(src.view())
+                    .and(dst.view_mut())
+                    .for_each(|srcp, dstp| {
+                        *dstp = *srcp;
+                    });
             }
         }
 
         step_description.finalize();
-        let json_str = serde_json::to_string(&step_description)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let json_str = serde_json::to_string(&step_description).map_err(std::io::Error::other)?;
         trace!(policy_step = json_str);
 
         // extract the outputs
         let commands = outputs[0]
             .try_extract_array::<f32>()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+            .map_err(std::io::Error::other)?
             .into_dimensionality::<ndarray::Dim<[usize; 1]>>()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         let actuator_states = &mut robot_description.actuators.actuator_states;
         for (i, command) in commands.iter().enumerate() {
@@ -814,7 +779,7 @@ impl Operate {
                 let quat = nalgebra::UnitQuaternion::from_quaternion(quat);
                 // scalar part is w
                 let (_, _, yaw) = quat.euler_angles();
-                log::warn!("Current heading yaw: {}", yaw);
+                log::warn!("Current heading yaw: {yaw}");
             }
             DataType::ProjectedGravity => {
                 let unit_quat =
@@ -853,7 +818,7 @@ impl Operate {
                     robot_description.initial_imu.quaternion,
                 );
                 let (_, _, yaw) = unit_quat.euler_angles();
-                log::warn!("Initial heading yaw: {}", yaw);
+                log::warn!("Initial heading yaw: {yaw}");
                 arr[0] = yaw as f32;
             }
             _ => {
@@ -868,6 +833,7 @@ impl Operate {
 }
 
 impl State for Operate {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let mut shared_state = self.shared_state;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -11,6 +11,12 @@ pub struct KeyboardManager {
 
 use crate::policy_control::{CommandType, InputState};
 
+impl Default for KeyboardManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyboardManager {
     pub fn new() -> Self {
         KeyboardManager {
@@ -38,9 +44,9 @@ impl KeyboardManager {
                             process::exit(0);
                         }
                         _ => {
-                            pending_events.push_back(key).map_err(|_| {
-                                io::Error::new(io::ErrorKind::Other, "Event queue is full")
-                            })?;
+                            pending_events
+                                .push_back(key)
+                                .map_err(|_| io::Error::other("Event queue is full"))?;
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ use futures::stream::StreamExt;
 
 use telemetry::{
     forwarder::{EventRecord, HeaplessForwardLayer},
-    telemetry::start_pipeline,
+    telemetry_main::start_pipeline,
 };
 use tracing::{Level, Metadata, debug, error, info, trace, warn};
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt};
@@ -172,7 +172,7 @@ fn main() {
     // wait for the telemetry thread to finish
     match jh.join() {
         Ok(_) => println!("Background thread finished successfully"),
-        Err(e) => eprintln!("Background thread panicked: {:?}", e),
+        Err(e) => eprintln!("Background thread panicked: {e:?}"),
     }
 
     println!("Cleanup complete, exiting");

--- a/src/policy_control.rs
+++ b/src/policy_control.rs
@@ -36,7 +36,7 @@ impl CommandType {
             )),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!("Unsupported input state dimensions: {}", dims),
+                format!("Unsupported input state dimensions: {dims}"),
             )),
         }
     }
@@ -226,7 +226,7 @@ impl BartControlVectorInputState {
 
 impl InputState for BartControlVectorInputState {
     fn update(&mut self, key: KeyEvent) -> std::io::Result<()> {
-        log::info!("Updating BartControlVectorInputState with key: {:?}", key);
+        log::info!("Updating BartControlVectorInputState with key: {key:?}");
         match key.code {
             KeyCode::Char('w') => self.cmds[ControlVectorDType::XVel] += self.step_size,
             KeyCode::Char('s') => self.cmds[ControlVectorDType::XVel] -= self.step_size,

--- a/src/robot_description.rs
+++ b/src/robot_description.rs
@@ -181,6 +181,12 @@ pub struct ActuatorStateStore {
     pub actuator_states: EnumMap<ActuatorId, ActuatorState>, // 20 actuators
 }
 
+impl Default for ActuatorStateStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ActuatorStateStore {
     pub fn new() -> Self {
         Self {
@@ -210,6 +216,10 @@ impl ActuatorStateStore {
 
     pub fn len(&self) -> usize {
         self.actuator_states.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.actuator_states.len() == 0
     }
 }
 
@@ -324,6 +334,12 @@ pub struct RobotDescription {
     pub kd_scale: f64,
 }
 
+impl Default for RobotDescription {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RobotDescription {
     pub fn new() -> Self {
         let args = Args::parse();
@@ -408,6 +424,6 @@ impl RobotDescription {
             DataType::InitialHeading => 1,
             DataType::Time => 1,
         };
-        return vec![ret];
+        vec![ret]
     }
 }

--- a/src/robstride.rs
+++ b/src/robstride.rs
@@ -30,34 +30,51 @@ impl From<ActuatorRequest> for crate::socketcan::CanFrame {
     }
 }
 
-impl Into<ActuatorResponse> for crate::socketcan::CanFrame {
-    fn into(mut self) -> ActuatorResponse {
-        self.can_id ^= 0x8000_0000; // remove EFF FLAG
-        let mux = mux_from_can_frame(&self);
+impl From<crate::socketcan::CanFrame> for ActuatorResponse {
+    fn from(mut val: crate::socketcan::CanFrame) -> Self {
+        val.can_id ^= 0x8000_0000; // remove EFF FLAG
+        let mux = mux_from_can_frame(&val);
         match mux {
-            0x00 => ActuatorResponse::ObtainId(bytemuck::must_cast::<Self, ObtainIdResponse>(self)),
-            0x02 => ActuatorResponse::Feedback(bytemuck::must_cast::<Self, FeedbackResponse>(self)),
-            _ => panic!("Unknown mux value: {}", mux),
+            0x00 => ActuatorResponse::ObtainId(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                ObtainIdResponse,
+            >(val)),
+            0x02 => ActuatorResponse::Feedback(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                FeedbackResponse,
+            >(val)),
+            _ => panic!("Unknown mux value: {mux}"),
         }
     }
 }
 
-impl Into<ActuatorRequest> for crate::socketcan::CanFrame {
-    fn into(mut self) -> ActuatorRequest {
-        self.can_id &= !0x80; // clear EFF FLAG
-        let mux = mux_from_can_frame(&self);
+impl From<crate::socketcan::CanFrame> for ActuatorRequest {
+    fn from(mut val: crate::socketcan::CanFrame) -> Self {
+        val.can_id &= !0x80; // clear EFF FLAG
+        let mux = mux_from_can_frame(&val);
         // TODO: change mux values from u8 to an enum
         match mux {
-            0x00 => ActuatorRequest::ObtainId(bytemuck::must_cast::<Self, ObtainIdRequest>(self)),
-            0x01 => {
-                ActuatorRequest::Control(bytemuck::must_cast::<Self, ControlCommandRequest>(self))
-            }
-            0x11 => ActuatorRequest::ReadParam(bytemuck::must_cast::<Self, ReadParamRequest>(self)),
-            0x03 => {
-                ActuatorRequest::MotorEnable(bytemuck::must_cast::<Self, MotorEnableRequest>(self))
-            }
-            0x02 => ActuatorRequest::Feedback(bytemuck::must_cast::<Self, FeedbackRequest>(self)),
-            _ => panic!("Unknown mux value: {}", mux),
+            0x00 => ActuatorRequest::ObtainId(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                ObtainIdRequest,
+            >(val)),
+            0x01 => ActuatorRequest::Control(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                ControlCommandRequest,
+            >(val)),
+            0x11 => ActuatorRequest::ReadParam(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                ReadParamRequest,
+            >(val)),
+            0x03 => ActuatorRequest::MotorEnable(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                MotorEnableRequest,
+            >(val)),
+            0x02 => ActuatorRequest::Feedback(bytemuck::must_cast::<
+                crate::socketcan::CanFrame,
+                FeedbackRequest,
+            >(val)),
+            _ => panic!("Unknown mux value: {mux}"),
         }
     }
 }
@@ -247,7 +264,7 @@ impl ReadParamRequest {
             mux: 0x11,
             index: index.to_le(),
             actuator_can_id,
-            host_id: host_id as u16,
+            host_id,
             len: 8,
             ..Default::default()
         }
@@ -448,27 +465,25 @@ impl ActuatorCanClient {
         response: &CanFrame,
     ) -> std::io::Result<Option<ActuatorFeedbackUpdate>> {
         if self.last_request.is_none() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 "No current transaction to handle response for",
             ));
         }
 
         // Check if the response matches the current transaction
         if let Some(ref cur_req) = self.last_request {
-            if mux_from_can_frame(&response) != cur_req.response_mux() {
+            if mux_from_can_frame(response) != cur_req.response_mux() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!(
                         "Response ID {} does not match current transaction {}",
-                        mux_from_can_frame(&response),
+                        mux_from_can_frame(response),
                         cur_req.response_mux()
                     ),
                 ));
             }
         } else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 "No current transaction to handle response for",
             ));
         }
@@ -578,7 +593,7 @@ impl From<u8> for RobstrideActuatorType {
             44 => RobstrideActuatorType::Robstride04, // right_knee_04
             45 => RobstrideActuatorType::Robstride02, // right_ankle_02
 
-            _ => panic!("Invalid Robstride actuator ID: {}", id),
+            _ => panic!("Invalid Robstride actuator ID: {id}"),
         }
     }
 }

--- a/src/state_machine_utils.rs
+++ b/src/state_machine_utils.rs
@@ -12,7 +12,7 @@ macro_rules! state_machine {
             }
 
             // 2) Transition result
-            struct StateTransitionResult {
+            pub struct StateTransitionResult {
                 state: StateStore,
                 result: ::std::io::Result<()>,
             }
@@ -27,7 +27,7 @@ macro_rules! state_machine {
             }
 
             // 5) Taggable trait and auto-impl for each state
-            trait Taggable {
+            pub trait Taggable {
                 fn tag(&self) -> StateTag;
             }
             $(
@@ -39,7 +39,7 @@ macro_rules! state_machine {
             )+
 
             // 6) State trait depends on Taggable
-            trait State: Taggable {
+            pub trait State: Taggable {
                 fn transition_fut(self) -> impl std::future::Future<Output = StateTransitionResult>;
             }
 

--- a/src/telemetry/forwarder.rs
+++ b/src/telemetry/forwarder.rs
@@ -72,7 +72,7 @@ impl<'a> Visit for FieldCollector<'a> {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
         let mut s = HString::new();
         // format into inline buffer
-        let _ = write!(&mut s, "{:?}", value);
+        let _ = write!(&mut s, "{value:?}");
         let _ = self.0.push(FieldRecord {
             name: field.name(),
             value: FieldValue::Debug(s),

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,4 +1,4 @@
 pub mod forwarder;
 pub mod multi_fd_writer;
-pub mod telemetry;
+pub mod telemetry_main;
 pub mod utils;

--- a/src/telemetry/multi_fd_writer.rs
+++ b/src/telemetry/multi_fd_writer.rs
@@ -61,7 +61,7 @@ impl BufferedIoUring {
             )
         };
 
-        if raw_ptr == libc::MAP_FAILED {
+        if std::ptr::eq(raw_ptr, libc::MAP_FAILED) {
             panic!("mmap failed: {}", io::Error::last_os_error());
         }
         if unsafe { libc::mlock(raw_ptr, num_pages * PAGE_SIZE) } != 0 {

--- a/src/telemetry/telemetry_main.rs
+++ b/src/telemetry/telemetry_main.rs
@@ -59,8 +59,7 @@ pub fn start_pipeline(
 
         // TODO use ring buffer that is allocated once
         // do not create a filled vec as we have a limit on max buffer size
-        let mut batch_buf: Vec<u8> = vec![];
-        batch_buf.reserve(BUF_SIZE);
+        let mut batch_buf: Vec<u8> = Vec::with_capacity(BUF_SIZE);
 
         while let Ok(evt) = rx.recv() {
             // Serialize event into batch_buf (ensure capacity)

--- a/src/typestate_serial.rs
+++ b/src/typestate_serial.rs
@@ -68,6 +68,7 @@ impl Reset {
 }
 
 impl State for Reset {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let ss = self.shared_state.as_mut().project();
@@ -99,6 +100,7 @@ impl State for Reset {
 }
 
 impl State for Operate {
+    #[allow(clippy::manual_async_fn)]
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             StateTransitionResult {

--- a/src/typestate_socket2.rs
+++ b/src/typestate_socket2.rs
@@ -50,7 +50,7 @@ where
     Error,
 }
 
-struct StateTransitionResult<C, O>
+pub struct StateTransitionResult<C, O>
 where
     C: SocketConfigurator + Unpin,
     O: SocketOperator + Unpin,
@@ -301,9 +301,9 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SocketStorage::Configure(socket) => write!(f, "SocketStorage::Configure({:?})", socket),
+            SocketStorage::Configure(socket) => write!(f, "SocketStorage::Configure({socket:?})"),
             SocketStorage::ConfigureToOperate(_) => write!(f, "SocketStorage::ConfigureToOperate"),
-            SocketStorage::Operate(socket) => write!(f, "SocketStorage::Operate({:?})", socket),
+            SocketStorage::Operate(socket) => write!(f, "SocketStorage::Operate({socket:?})"),
         }
     }
 }


### PR DESCRIPTION
- Fix build.rs needless borrows and format strings
- Make OutputType enum public in hiwonder.rs
- Fix format strings, casts, and Into->From in robstride.rs
- Fix format string in main.rs
- Make state machine traits and structs public
- Fix telemetry module naming conflict
- Add Default implementations and is_empty methods
- Fix pointer equality checks
- Add allow attributes for manual async fn warnings
- Replace io::Error::new with io::Error::other
- Remove unnecessary clone() calls on Copy types
- Fix inline format string arguments
- Remove needless borrows and returns
- Add missing Default trait implementations
- Fix redundant patterns and closures