### PR TITLE
Use a global Config struct for arguments & accept log file as an argument

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -9,6 +9,8 @@ use std::{
 };
 use tracing::{debug, error, info, warn};
 
+use crate::config::Config;
+
 use crate::imu::{self, ImuManager};
 
 use crate::robot_description::{self, ActuatorId, RobotDescription};
@@ -38,15 +40,9 @@ pub struct Store {
     kb_manager: crate::keyboard::KeyboardManager,
 }
 
-impl Default for Store {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Store {
-    pub fn new() -> Self {
-        let robot_description = RobotDescription::new();
+    pub fn new(config: &Config) -> Self {
+        let robot_description = RobotDescription::new(config);
 
         let model_manager = ModelManager::new("model.kinfer", &robot_description)
             .expect("Failed to create model manager");
@@ -617,17 +613,11 @@ pub struct BehaviorManager {
     pending_fut: Option<StateFut>,
 }
 
-impl Default for BehaviorManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl BehaviorManager {
-    pub fn new() -> Self {
+    pub fn new(config: &Config) -> Self {
         Self {
             state: Some(StateStore::Reset(Reset {
-                shared_state: Box::pin(Store::new()),
+                shared_state: Box::pin(Store::new(config)),
             })),
             target: None,
             pending_fut: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Config {
+    pub policy_scale: f64,
+    pub kp_scale: f64,
+    pub kd_scale: f64,
+    pub log_path: PathBuf,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod actuator;
 pub mod actuator_manager;
 pub mod behavior;
 pub mod bytestream_fd;
+pub mod config;
 pub mod imu;
 pub mod inference;
 pub mod keyboard;
@@ -28,6 +29,8 @@ use std::task::{Context, Poll};
 
 use crate::robstride::{ObtainIdRequest, ObtainIdResponse};
 
+use config::Config;
+
 use socketcan::CanFrame;
 pub mod robstride;
 pub mod robstride_utils;
@@ -44,10 +47,11 @@ use tracing::{Level, Metadata, debug, error, info, trace, warn};
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt};
 
 use std::sync::mpsc;
+use std::path::PathBuf;
 
 use clap::Parser;
 #[derive(Debug, Parser)]
-#[command(name = "faux-rtos", about = "Parse three floats")]
+#[command(name = "faux-rtos", about = "Parse three floats and a path")]
 pub struct Args {
     /// scale factor for the policy
     #[arg(long, value_name = "FLOAT", default_value_t = 1.0)]
@@ -61,13 +65,13 @@ pub struct Args {
     #[arg(long, value_name = "FLOAT", default_value_t = 1.0)]
     kd_scale: f64,
 
-    /// derivative gain scale
+    /// path to log file
     #[arg(long, value_name = "PATH", default_value = "events.log")]
-    kinfer_log_path: String,
+    kinfer_log_path: PathBuf,
 }
 
-async fn driver() -> std::io::Result<()> {
-    let mut behavior_manager = behavior::BehaviorManager::new();
+async fn driver(config: &Config) -> std::io::Result<()> {
+    let mut behavior_manager = behavior::BehaviorManager::new(config);
     let mut pinned = unsafe { Pin::new_unchecked(&mut behavior_manager) };
     loop {
         // iterate over each SlowCounter in sc_vec
@@ -99,12 +103,22 @@ async fn driver() -> std::io::Result<()> {
 }
 
 fn main() {
+    // Parse command line arguments
     let args = Args::parse();
+
+    let config = Config {
+        policy_scale: args.policy_scale,
+        kp_scale: args.kp_scale,
+        kd_scale: args.kd_scale,
+        log_path: args.kinfer_log_path,
+    };
+
+
     // Setup telemetry before we do anything else
     let (tx, rx) = mpsc::sync_channel::<EventRecord>(1024 * 1024);
 
     // Spawn the thread that will format and log our data
-    let jh = start_pipeline(rx, &args.kinfer_log_path).expect("Failed to start telemetry pipeline");
+    let jh = start_pipeline(rx, &config.log_path).expect("Failed to start telemetry pipeline");
 
     let trace_only_filter = tracing_subscriber::filter::FilterFn::new(|metadata: &Metadata| {
         metadata.level() == &Level::TRACE && metadata.target().starts_with("faux_rtos")
@@ -142,7 +156,7 @@ fn main() {
     // handle driver and SIGINT
     let drv = async {
         tokio::select! {
-            result = driver() => {
+            result = driver(&config) => {
                 match result {
                     Ok(_) => {
                         info!("Driver finished successfully");

--- a/src/robot_description.rs
+++ b/src/robot_description.rs
@@ -4,6 +4,8 @@ use heapless::Deque;
 use nalgebra as na;
 use tracing::info;
 
+use crate::config::Config;
+
 pub fn normalize_actuator_qpos(mut qpos: f64) -> f64 {
     const TWO_PI: f64 = 2.0 * std::f64::consts::PI;
     // rem_euclid gives a value in [0, 2π)
@@ -310,23 +312,6 @@ pub enum DataType {
     Time,
 }
 
-use clap::Parser;
-#[derive(Debug, Parser)]
-#[command(name = "faux-rtos", about = "Parse three floats")]
-pub struct Args {
-    /// scale factor for the policy
-    #[arg(long, value_name = "FLOAT", default_value_t = 1.0)]
-    policy_scale: f64,
-
-    /// proportional gain scale
-    #[arg(long, value_name = "FLOAT", default_value_t = 1.0)]
-    kp_scale: f64,
-
-    /// derivative gain scale
-    #[arg(long, value_name = "FLOAT", default_value_t = 1.0)]
-    kd_scale: f64,
-}
-
 pub struct RobotDescription {
     pub actuators: ActuatorStateStore,
     pub imu: ImuData,
@@ -339,24 +324,16 @@ pub struct RobotDescription {
     pub kd_scale: f64,
 }
 
-impl Default for RobotDescription {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RobotDescription {
-    pub fn new() -> Self {
-        let args = Args::parse();
-        info!("Args; {:?}", args);
+    pub fn new(config: &Config) -> Self {
         Self {
             actuators: ActuatorStateStore::new(),
             imu: ImuData::default(),
             initial_imu: ImuData::default(),
             kb_pending_events: Deque::new(),
-            kp_scale: args.kp_scale,
-            kd_scale: args.kd_scale,
-            policy_scale: args.policy_scale,
+            kp_scale: config.kp_scale,
+            kd_scale: config.kd_scale,
+            policy_scale: config.policy_scale,
             home_position: enum_map! {
                 ActuatorId::Lsp => ActuatorCommand { qpos: 0.0, kp: 100.0, kd: 8.284, ..Default::default() },
                 ActuatorId::Lsr => ActuatorCommand { qpos: (10.0_f64).to_radians(), kp: 100.0, kd: 8.257, ..Default::default() },

--- a/src/telemetry/telemetry_main.rs
+++ b/src/telemetry/telemetry_main.rs
@@ -5,14 +5,14 @@ use std::os::unix::io::{AsFd, AsRawFd, OwnedFd};
 use std::net::UdpSocket;
 use std::os::unix::fs::OpenOptionsExt;
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::ptr;
 use std::thread;
 use std::time::Instant;
 
 use nix::libc;
 use std::sync::mpsc::Receiver;
-use tracing::error;
+use tracing::{info, error};
 
 use crate::telemetry::forwarder::{EventRecord, FieldValue};
 use crate::telemetry::multi_fd_writer::MultiFdWriter;
@@ -23,21 +23,14 @@ const BUF_SIZE: usize = 4 * 4096;
 /// spawns a thread that will handle the I/O operations (read events and write to disk)
 pub fn start_pipeline(
     rx: Receiver<EventRecord>,
-    log_path: &str,
+    log_path: &Path,
 ) -> io::Result<thread::JoinHandle<()>> {
-
-    println!("log path: {:?}", log_path);
-
-    let log_path = std::path::Path::new(log_path);
 
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    let log_path = log_path.canonicalize()
-    .unwrap_or_else(|_| panic!("Failed to canonicalize log path"));
-
-    println!("log path: {:?}", log_path);
+    info!("Logging to: {:?}", log_path);
 
     // Open log file for writing
     let file = OpenOptions::new()


### PR DESCRIPTION
# Problem
Firmware currently accepts command-line arguments for controlling policy-scale, kp-scale, and kd-scale. These arguments are parsed in `robot_description.rs`, rather than early on in `main`. This makes it difficult to add new arguments which affect other parts of the code--in this case an argument to specify where log files should be saved.

# Solution
Arguments are now parsed first thing, in `main`, and placed into a Config struct. This struct is then passed through a series of functions to `RobotDescription`. I've also added an argument for the log file.