### PR TITLE
fix imu and inital heading and clear queue

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -432,13 +432,15 @@ impl State for Home {
                 // can go to next state
                 info!("error to home: {}", err);
                 info!("Home position reached, press enter to run policy");
+                ss.kb_manager.wait_for_enter().await;
+                op_imu_manager.clear();
+                std::thread::sleep(std::time::Duration::from_millis(30));
                 // we need to arm the imu with the initial value. Again, this needs to be done once
                 // when we transition to Policy state.
                 op_imu_manager
                     .process_feedback(&mut ss.robot_description.imu)
                     .await;
                 ss.robot_description.initial_imu = ss.robot_description.imu;
-                ss.kb_manager.wait_for_enter().await;
 
                 return StateTransitionResult {
                     state: StateStore::Policy(Policy {

--- a/src/hiwonder.rs
+++ b/src/hiwonder.rs
@@ -1,5 +1,5 @@
 use std::io;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 /**
 
@@ -99,6 +99,7 @@ impl HiwonderImu {
     pub async fn parse_all(port: &mut OperationalPort) -> io::Result<ImuFeedback> {
         // read upto 1024
         let mut buf = [0u8; 1024];
+
         match port.read(&mut buf).await {
             Err(e) => return Err(e),
             Ok(0) => {
@@ -128,6 +129,11 @@ impl HiwonderImu {
         buf.chunks_exact(PACKET_SIZE).for_each(|chunk| {
             let frame: &HiwonderRawFrame = bytemuck::from_bytes(chunk);
             if frame.checksum() != frame.checksum {
+                warn!(
+                    "Checksum mismatch for frame: expected {}, got {}",
+                    frame.checksum(),
+                    frame.checksum,
+                );
                 return;
             }
             Self::merge_frame(frame, &mut fdbk);

--- a/src/imu.rs
+++ b/src/imu.rs
@@ -243,6 +243,24 @@ impl Operate {
 
         Ok(())
     }
+
+    pub fn clear(&mut self) -> std::io::Result<()> {
+        let mut shared_state = &mut self.shared_state;
+        let mut ss = shared_state.as_mut().project();
+
+        // get operational serial port
+        let typestate_serial::StateStore::Operate(op_port) = ss
+            .port
+            .as_mut()
+            .get_state_pinned()
+            .expect("serial port should be in Operate state")
+        else {
+            return Err(std::io::Error::other("serial port is not in Operate state"));
+        };
+
+        op_port.clear(tokio_serial::ClearBuffer::All);
+        Ok(())
+    }
 }
 
 impl State for Operate {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -30,24 +30,24 @@ impl KeyboardManager {
     ) -> std::io::Result<()> {
         // drain the buffered events
         while event::poll(Duration::from_millis(0))? {
-            if let event::Event::Key(key) = event::read()? {
-                if key.kind == event::KeyEventKind::Press {
-                    match key.code {
-                        event::KeyCode::Char('c')
-                            if key.modifiers.contains(event::KeyModifiers::CONTROL) =>
-                        {
-                            terminal::disable_raw_mode().unwrap_or(());
-                            process::exit(130);
-                        }
-                        event::KeyCode::Esc | event::KeyCode::Char('x') => {
-                            terminal::disable_raw_mode().unwrap_or(());
-                            process::exit(0);
-                        }
-                        _ => {
-                            pending_events
-                                .push_back(key)
-                                .map_err(|_| io::Error::other("Event queue is full"))?;
-                        }
+            if let event::Event::Key(key) = event::read()?
+                && key.kind == event::KeyEventKind::Press
+            {
+                match key.code {
+                    event::KeyCode::Char('c')
+                        if key.modifiers.contains(event::KeyModifiers::CONTROL) =>
+                    {
+                        terminal::disable_raw_mode().unwrap_or(());
+                        process::exit(130);
+                    }
+                    event::KeyCode::Esc | event::KeyCode::Char('x') => {
+                        terminal::disable_raw_mode().unwrap_or(());
+                        process::exit(0);
+                    }
+                    _ => {
+                        pending_events
+                            .push_back(key)
+                            .map_err(|_| io::Error::other("Event queue is full"))?;
                     }
                 }
             }


### PR DESCRIPTION
There is stale data in the uart queue that can cause initial heading to be erroneous. This commit clears the queue before we move to the Policy state.