### PR TITLE
Add emulators for robstride actuators and IMU

### DIFF
--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -69,10 +69,65 @@ class ActuatorEmulator:
         self.actuator_id = actuator_id
         self.host_id = host_id
         self.verbose = verbose
+        
+        # Internal state
+        self.position = 0.0  # Current position in radians
+        self.velocity = 0.0  # Current velocity 
+        self.torque = 0.0    # Current torque
+        self.temperature = 25.0  # Temperature in Celsius
 
     def log(self, *a, **kw):
         if self.verbose:
             print(*a, **kw)
+
+    def decode_control_command(self, data: bytes):
+        """Decode control command data and update internal state"""
+        if len(data) < 8:
+            return
+        
+        # Parse the 8-byte data payload (big-endian u16 values)
+        # angle_scale, velocity_scale, kp_scale, kd_scale
+        angle_scale, velocity_scale, kp_scale, kd_scale = struct.unpack(">HHHH", data)
+        
+        # Convert scaled values back to physical values
+        # Using typical robstride ranges: angle ±4π, velocity ±0.5, etc.
+        ANGLE_RANGE = 4.0 * 3.14159265359  # ±4π radians
+        VELOCITY_RANGE = 0.5  # ±0.5 rad/s
+        
+        # Scale from u16 range [0, 65535] to physical range [-range, +range]
+        if angle_scale != 0x7FFF:  # 0x7FFF typically means "no command"
+            self.position = (angle_scale / 32767.5) * ANGLE_RANGE - ANGLE_RANGE
+        
+        if velocity_scale != 0x7FFF:
+            self.velocity = (velocity_scale / 32767.5) * VELOCITY_RANGE - VELOCITY_RANGE
+        
+        self.log(f"[Actuator {self.actuator_id}] Updated position: {self.position:.3f} rad, velocity: {self.velocity:.3f} rad/s")
+
+    def get_feedback_data(self):
+        """Generate feedback response data"""
+        # Convert physical values back to scaled format for feedback
+        # Using typical ranges
+        ANGLE_RANGE = 4.0 * 3.14159265359
+        VELOCITY_RANGE = 0.5
+        TORQUE_RANGE = 14.0
+        
+        # Scale to u16 range [0, 65535] centered at 32767
+        angle_scaled = int((self.position + ANGLE_RANGE) / (2 * ANGLE_RANGE) * 65535)
+        vel_scaled = int((self.velocity + VELOCITY_RANGE) / (2 * VELOCITY_RANGE) * 65535)
+        torque_scaled = int((self.torque + TORQUE_RANGE) / (2 * TORQUE_RANGE) * 65535)
+        temp_scaled = int(self.temperature * 10)  # Temperature in 0.1°C units
+        
+        # Clamp to valid u16 range
+        angle_scaled = max(0, min(65535, angle_scaled))
+        vel_scaled = max(0, min(65535, vel_scaled))
+        torque_scaled = max(0, min(65535, torque_scaled))
+        temp_scaled = max(0, min(65535, temp_scaled))
+        
+        return struct.pack(">HHHH", 
+                          angle_scaled & 0xFFFF,
+                          vel_scaled & 0xFFFF, 
+                          torque_scaled & 0xFFFF,
+                          temp_scaled & 0xFFFF)
 
     def handle(self, bus, can_id: int, dlc: int, data: bytes):
         mux = mux_from_can_id(can_id)
@@ -91,17 +146,7 @@ class ActuatorEmulator:
 
         elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
             resp_can_id = make_response_can_id(can_id, 0x02)
-            angle = 0
-            vel = 0
-            torque = 0
-            temp = int(25.0 * 10)
-            data_bytes = struct.pack(
-                ">HHHH",
-                angle & 0xFFFF,
-                vel & 0xFFFF,
-                torque & 0xFFFF,
-                temp & 0xFFFF,
-            )
+            data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse
@@ -114,30 +159,14 @@ class ActuatorEmulator:
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x01:  # ControlCommandRequest -> reply with feedback
+            self.decode_control_command(data)
             resp_can_id = make_response_can_id(can_id, 0x02)
-            angle = 0
-            vel = 0
-            torque = 0
-            temp = int(25.0 * 10)
-            data_bytes = struct.pack(
-                ">HHHH",
-                angle & 0xFFFF,
-                vel & 0xFFFF,
-                torque & 0xFFFF,
-                temp & 0xFFFF,
-            )
+            data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x03:  # MotorEnableRequest -> reply with feedback
             resp_can_id = make_response_can_id(can_id, 0x02)
-            temp = int(25.0 * 10)
-            data_bytes = struct.pack(
-                ">HHHH",
-                0,
-                0,
-                0,
-                temp & 0xFFFF,
-            )
+            data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 
         else:

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""CAN motor emulator for testing the firmware.
+
+This script opens a raw SocketCAN socket, reads 16-byte CAN frames using the
+same layout as `src/socketcan.rs` (u32 can_id, 4 bytes of header, 8 bytes data),
+and replies to a subset of Robstride requests so the Rust firmware can't tell
+the difference.
+
+It intentionally avoids external dependencies and uses Python's builtin
+socket/struct modules.
+
+Features implemented:
+ - Respond to ObtainId (mux 0x00) with a fake MCU UID
+ - Respond to FeedbackRequest (mux 0x02) with plausible sensor values
+ - Respond to ReadParamRequest (mux 0x11) by echoing index and returning 0
+ - Optionally periodically broadcast Feedback frames
+
+Usage: scripts/can_motor_emulator.py --iface vcan0 --actuator-id 5 --dry-run
+"""
+
+import argparse
+import socket
+import struct
+import time
+import threading
+import os
+import sys
+import random
+
+# Frame layout used by the Rust code: packed repr with total size 16 bytes
+# struct CanFrame { u32 can_id; u8 len; u8 pad; u8 res0; u8 len8_dlc; u8 data[8]; }
+FRAME_FMT = "<I4B8s"  # little-endian: u32, 4 x u8, 8 bytes
+FRAME_SIZE = struct.calcsize(FRAME_FMT)
+
+
+def pack_frame(can_id: int, dlc: int, data: bytes) -> bytes:
+    data = (data or b"")[:8]
+    data = data.ljust(8, b"\x00")
+    pad = 0
+    res0 = 0
+    len8_dlc = 0
+    return struct.pack(FRAME_FMT, can_id & 0xFFFFFFFF, dlc & 0xFF, pad, res0, len8_dlc, data)
+
+
+def unpack_frame(buf: bytes):
+    can_id, dlc, pad, res0, len8_dlc, data = struct.unpack(FRAME_FMT, buf)
+    return can_id, dlc, bytes(data)
+
+
+def mux_from_can_id(can_id: int) -> int:
+    # mux is stored in the highest-order byte & 0x1F (frame[3] & 0x1F)
+    return (can_id >> 24) & 0x1F
+
+
+def actuator_id_from_can_id(can_id: int) -> int:
+    return (can_id >> 8) & 0xFF
+
+
+def make_response_can_id(request_can_id: int, resp_mux: int) -> int:
+    # Build response can_id: preserve lower 24 bits, set mux in top byte,
+    # and set EFF flag (0x8000_0000) so the Rust code recognizes it as a response
+    lower = request_can_id & 0x00FFFFFF
+    top = (resp_mux & 0x1F) << 24
+    return lower | top | 0x80000000
+
+
+class CanMotorEmulator:
+    def __init__(self, iface: str, actuator_id: int, host_id: int, periodic: float = 0.0, dry_run=False, verbose=False):
+        self.iface = iface
+        self.actuator_id = actuator_id
+        self.host_id = host_id
+        self.periodic = periodic
+        self.dry_run = dry_run
+        self.verbose = verbose
+        self.sock = None
+        self._stop = False
+
+    def log(self, *a, **kw):
+        if self.verbose:
+            print(*a, **kw)
+
+    def open(self):
+        if self.dry_run:
+            self.log("dry-run: not opening socket")
+            return
+        # AF_CAN raw socket
+        s = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+        # bind to interface
+        s.bind((self.iface,))
+        self.sock = s
+        self.log(f"bound to {self.iface}")
+
+    def close(self):
+        self._stop = True
+        if self.sock:
+            self.sock.close()
+
+    def send(self, can_id: int, data: bytes):
+        frame = pack_frame(can_id, 8, data)
+        if self.dry_run:
+            self.log("DRY SEND -> can_id=0x{:08X} data={}".format(can_id, data.hex()))
+            return
+        self.sock.send(frame)
+        self.log("SENT -> can_id=0x{:08X} data={}".format(can_id, data.hex()))
+
+    def handle_request(self, can_id: int, dlc: int, data: bytes):
+        mux = mux_from_can_id(can_id)
+        req_act_id = actuator_id_from_can_id(can_id)
+        self.log(f"REQ can_id=0x{can_id:08X} mux=0x{mux:02X} act={req_act_id} dlc={dlc} data={data.hex()}")
+
+        # Only respond for requests targeting our actuator id (or broadcast 0xFF)
+        if req_act_id not in (self.actuator_id, 0xFF):
+            self.log(f"ignoring request for actuator {req_act_id}")
+            return
+
+        if mux == 0x00:  # ObtainIdRequest -> ObtainIdResponse
+            resp_can_id = make_response_can_id(can_id, 0x00)
+            # mcu_uid: 8 bytes, create deterministic-ish value
+            mcu_uid = (0xDEADBEEFCAF00000 | (self.actuator_id & 0xFF)) & 0xFFFFFFFFFFFFFFFF
+            data_bytes = mcu_uid.to_bytes(8, "little")
+            self.send(resp_can_id, data_bytes)
+
+        elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
+            resp_can_id = make_response_can_id(can_id, 0x02)
+            # angle_scale_be, angular_vel_scale_be, torque_be, temp_be each u16 (big-endian)
+            # Provide neutral values: angle=0, vel=0, torque=0, temp=250 => 25.0C
+            angle = 0
+            vel = 0
+            torque = 0
+            temp = int(25.0 * 10)  # protocol uses temp*10
+            data_bytes = struct.pack(
+                ">HHHH",  # big-endian u16 fields
+                angle & 0xFFFF,
+                vel & 0xFFFF,
+                torque & 0xFFFF,
+                temp & 0xFFFF,
+            )
+            self.send(resp_can_id, data_bytes)
+
+        elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse
+            resp_can_id = make_response_can_id(can_id, 0x11)
+            # echo index (first two bytes of data are index in request little-endian per request impl)
+            if len(data) >= 2:
+                index = int.from_bytes(data[0:2], "little")
+            else:
+                index = 0
+            # Build response data: index(u16), res1(u16)=0, value(u32)=0
+            data_bytes = struct.pack("<HHI", index & 0xFFFF, 0, 0)
+            self.send(resp_can_id, data_bytes)
+
+        elif mux == 0x03:  # MotorEnableRequest -> reply with feedback to indicate enabled
+            resp_can_id = make_response_can_id(can_id, 0x02)
+            temp = int(25.0 * 10)
+            data_bytes = struct.pack(
+                ">HHHH",
+                0,
+                0,
+                0,
+                temp & 0xFFFF,
+            )
+            self.send(resp_can_id, data_bytes)
+
+        else:
+            self.log(f"no handler for mux=0x{mux:02X}")
+
+    def reader_loop(self):
+        while not self._stop:
+            try:
+                if self.dry_run:
+                    time.sleep(0.1)
+                    continue
+                buf = self.sock.recv(FRAME_SIZE)
+                if len(buf) < FRAME_SIZE:
+                    self.log("short read: ", len(buf))
+                    continue
+                can_id, dlc, data = unpack_frame(buf)
+                self.handle_request(can_id, dlc, data)
+            except OSError as e:
+                self.log("socket error:", e)
+                break
+
+    def periodic_feedback_loop(self):
+        # Periodically broadcast feedback frames for our actuator id
+        if self.periodic <= 0:
+            return
+        while not self._stop:
+            # Build a fake feedback frame
+            # Build a can_id: put actuator id in bits 15-8 and mux 0x02 in top byte, set EFF
+            can_id = ((0x02 & 0x1F) << 24) | ((self.actuator_id & 0xFF) << 8) | 0x80000000
+            temp = int(25.0 * 10)
+            data_bytes = struct.pack(
+                ">HHHH",
+                0,
+                0,
+                0,
+                temp & 0xFFFF,
+            )
+            self.send(can_id, data_bytes)
+            time.sleep(1.0 / self.periodic)
+
+    def run(self):
+        self.open()
+        rt = threading.Thread(target=self.reader_loop, daemon=True)
+        rt.start()
+        pt = None
+        if self.periodic > 0:
+            pt = threading.Thread(target=self.periodic_feedback_loop, daemon=True)
+            pt.start()
+
+        try:
+            while True:
+                time.sleep(0.2)
+        except KeyboardInterrupt:
+            self.log("stopping")
+            self.close()
+
+
+def main():
+    p = argparse.ArgumentParser(description="CAN motor emulator (SocketCAN)")
+    p.add_argument("--iface", default=os.environ.get("CAN_IFACE", "vcan0"), help="CAN interface (default vcan0)")
+    p.add_argument("--actuator-id", type=int, default=1, help="Actuator CAN ID (0-255)")
+    p.add_argument("--host-id", type=int, default=1, help="Host ID to emulate")
+    p.add_argument("--periodic", type=float, default=0.0, help="Periodic feedback rate (Hz). 0 = disabled")
+    p.add_argument("--dry-run", action="store_true", help="Don't open socket; just print actions")
+    p.add_argument("--verbose", "-v", action="store_true")
+    args = p.parse_args()
+
+    emu = CanMotorEmulator(args.iface, args.actuator_id, args.host_id, args.periodic, args.dry_run, args.verbose)
+    emu.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -57,11 +57,11 @@ def actuator_id_from_can_id(can_id: int) -> int:
 
 
 def make_response_can_id(request_can_id: int, resp_mux: int) -> int:
-    # Build response can_id: preserve lower 24 bits, set mux in top byte,
-    # and set EFF flag (0x8000_0000) so the Rust code recognizes it as a response
+    # Build response can_id: preserve lower 24 bits, set mux in top byte
+    # No EFF flag needed - the real responses don't use it
     lower = request_can_id & 0x00FFFFFF
     top = (resp_mux & 0x1F) << 24
-    return lower | top | 0x80000000
+    return lower | top
 
 
 class ActuatorEmulator:

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -26,13 +26,30 @@ import threading
 import os
 import sys
 import random
+from kscale_vr_teleop.analysis.rerun_loader_urdf import URDFLogger
+from kscale_vr_teleop._assets import ASSETS_DIR
+import rerun as rr
 
+logger = URDFLogger(ASSETS_DIR/'kbot_legless/robot.urdf')
+motor_id_to_joint_mapping = {
+    11: "dof_left_shoulder_pitch_03",
+    12: "dof_left_shouldeR_roll_03",
+    13: "dof_left_shoulder_yaw_02",
+    14: "dof_left_elbow_02",
+    15: "dof_left_wrist_00",
+    21: "dof_right_shoulder_pitch_03",
+    22: "dof_right_shoulder_roll_03",
+    23: "dof_right_elbow_yaw_02",
+    24: "dof_right_elbow_pitch_02",
+    25: "dof_right_wrist_yaw_02",
+}
 # Frame layout used by the Rust code: packed repr with total size 16 bytes
 # struct CanFrame { u32 can_id; u8 len; u8 pad; u8 res0; u8 len8_dlc; u8 data[8]; }
 FRAME_FMT = "<I4B8s"  # little-endian: u32, 4 x u8, 8 bytes
 FRAME_SIZE = struct.calcsize(FRAME_FMT)
 
 
+rr.init("can_motor_emulator", spawn=True)
 # pub struct CanFrame {
 #     pub can_id: u32,
 #     pub len: u8,
@@ -293,6 +310,11 @@ class BusEmulator:
                     continue
                 can_id, dlc, data = unpack_frame(buf)
                 self.dispatch(can_id, dlc, data)
+                joints_config = {
+                    motor_id_to_joint_mapping[act.actuator_id]: act.position
+                    for act in self.actuators.values()
+                }
+                logger.log(joints_config)
             except OSError as e:
                 self.log(f"[{self.iface}] socket error: {e}")
                 break

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -53,7 +53,7 @@ def mux_from_can_id(can_id: int) -> int:
 
 
 def actuator_id_from_can_id(can_id: int) -> int:
-    return (can_id >> 8) & 0xFF
+    return can_id & 0xFF
 
 
 def make_response_can_id(request_can_id: int, resp_mux: int) -> int:
@@ -111,6 +111,21 @@ class ActuatorEmulator:
             else:
                 index = 0
             data_bytes = struct.pack("<HHI", index & 0xFFFF, 0, 0)
+            bus.send(resp_can_id, data_bytes)
+
+        elif mux == 0x01:  # ControlCommandRequest -> reply with feedback
+            resp_can_id = make_response_can_id(can_id, 0x02)
+            angle = 0
+            vel = 0
+            torque = 0
+            temp = int(25.0 * 10)
+            data_bytes = struct.pack(
+                ">HHHH",
+                angle & 0xFFFF,
+                vel & 0xFFFF,
+                torque & 0xFFFF,
+                temp & 0xFFFF,
+            )
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x03:  # MotorEnableRequest -> reply with feedback
@@ -248,8 +263,9 @@ def main():
             bus.close()
         sys.exit(0)
 
-    # Default behaviour: launch two buses for development convenience
-    # can0: actuators 11-16, can1: actuators 21-26
+    # Default behaviour: launch two buses to match firmware configuration
+    # can0: actuators 11-16 (left arm)
+    # can1: actuators 21-26 (right arm) - based on actual CAN traffic
     default_buses = [
         ("can0", list(range(11, 17))),
         ("can1", list(range(21, 27))),

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -83,11 +83,14 @@ class ActuatorEmulator:
         self.host_id = host_id
         self.verbose = verbose
         
-        # Internal state
-        self.position = 0.0  # Current position in radians
+        # Internal state - give each actuator a different initial position for debugging
+        self.position = 0.0#(actuator_id % 6) * 0.5  # 0, 0.5, 1.0, 1.5, 2.0, 2.5 radians
         self.velocity = 0.0  # Current velocity 
         self.torque = 0.0    # Current torque
         self.temperature = 25.0  # Temperature in Celsius
+        
+        if verbose:
+            print(f"ActuatorEmulator {actuator_id} initialized with position {self.position} radians")
 
     def log(self, *a, **kw):
         if self.verbose:
@@ -107,27 +110,44 @@ class ActuatorEmulator:
         ANGLE_RANGE = 4.0 * 3.14159265359  # ±4π radians
         VELOCITY_RANGE = 0.5  # ±0.5 rad/s
         
-        # Scale from u16 range [0, 65535] to physical range [-range, +range]
+        # Calculate target values but DON'T overwrite current position immediately
+        # In a real actuator, this would be handled by a control loop
         if angle_scale != 0x7FFF:  # 0x7FFF typically means "no command"
-            self.position = (angle_scale / 32767.5) * ANGLE_RANGE - ANGLE_RANGE
+            target_position = (angle_scale / 32767.5) * ANGLE_RANGE - ANGLE_RANGE
+            self.position = target_position
+            self.log(f"[Actuator {self.actuator_id}] Target position: {target_position:.3f} rad (keeping current: {self.position:.3f})")
         
         if velocity_scale != 0x7FFF:
-            self.velocity = (velocity_scale / 32767.5) * VELOCITY_RANGE - VELOCITY_RANGE
+            target_velocity = (velocity_scale / 32767.5) * VELOCITY_RANGE - VELOCITY_RANGE
+            self.velocity = target_velocity
+            self.log(f"[Actuator {self.actuator_id}] Target velocity: {target_velocity:.3f} rad/s (keeping current: {self.velocity:.3f})")
         
-        self.log(f"[Actuator {self.actuator_id}] Updated position: {self.position:.3f} rad, velocity: {self.velocity:.3f} rad/s")
+        # Note: In a real system, you'd implement a control loop here that gradually
+        # moves the actuator toward the target position/velocity
 
     def get_feedback_data(self):
         """Generate feedback response data - sensor data only (8 bytes)"""
-        # Convert physical values back to scaled format for feedback
-        # Using typical ranges
-        ANGLE_RANGE = 4.0 * 3.14159265359
-        VELOCITY_RANGE = 0.5
-        TORQUE_RANGE = 14.0
+        # Physical ranges (from robstride_utils.rs)
+        ANGLE_MIN = -4.0 * 3.14159265359  # -4π
+        ANGLE_MAX = 4.0 * 3.14159265359   # +4π
+        VEL_MIN = -0.5
+        VEL_MAX = 0.5
+        TORQUE_MIN = -14.0
+        TORQUE_MAX = 14.0
         
-        # Scale to u16 range [0, 65535] centered at 32767
-        angle_scaled = int((self.position + ANGLE_RANGE) / (2 * ANGLE_RANGE) * 65535)
-        vel_scaled = int((self.velocity + VELOCITY_RANGE) / (2 * VELOCITY_RANGE) * 65535)
-        torque_scaled = int((self.torque + TORQUE_RANGE) / (2 * TORQUE_RANGE) * 65535)
+        # CAN range is u16: 0 to 65535
+        CAN_MIN = 0.0
+        CAN_MAX = 65535.0
+        
+        # Scale physical values to CAN range using linear interpolation
+        # can_value = (physical - phys_min) / (phys_max - phys_min) * (can_max - can_min) + can_min
+        def scale_to_can(physical, phys_min, phys_max):
+            proportion = (physical - phys_min) / (phys_max - phys_min)
+            return int(CAN_MIN + proportion * (CAN_MAX - CAN_MIN))
+        
+        angle_scaled = scale_to_can(self.position, ANGLE_MIN, ANGLE_MAX)
+        vel_scaled = scale_to_can(self.velocity, VEL_MIN, VEL_MAX)
+        torque_scaled = scale_to_can(self.torque, TORQUE_MIN, TORQUE_MAX)
         temp_scaled = int(self.temperature * 10)  # Temperature in 0.1°C units
         
         # Clamp to valid u16 range
@@ -136,17 +156,20 @@ class ActuatorEmulator:
         torque_scaled = max(0, min(65535, torque_scaled))
         temp_scaled = max(0, min(65535, temp_scaled))
         
+        # Debug: print what we're encoding
+        self.log(f"[Actuator {self.actuator_id}] Encoding: pos={self.position:.3f} -> angle_scaled={angle_scaled} (0x{angle_scaled:04X})")
+        
         # The CAN frame structure when cast to FeedbackResponse:
         # Bytes 0-3: CAN ID contains [host_id, actuator_id, fault_flags, mux] 
         # Bytes 4-7: [len, pad, res0, len8_dlc] - these will be the first 4 bytes of data
         # Bytes 8-15: sensor data - these will be the last 8 bytes of data
         
         # First 4 bytes of data payload: [len, pad, res0, len8_dlc]
-        header = struct.pack("BBBB", 
-                           8,      # len at offset 4
-                           0,      # pad at offset 5
-                           0,      # res0 at offset 6  
-                           0)      # len8_dlc at offset 7
+        # header = struct.pack("BBBB", 
+        #                    8,      # len at offset 4
+        #                    0,      # pad at offset 5
+        #                    0,      # res0 at offset 6  
+        #                    0)      # len8_dlc at offset 7
         
         # Last 8 bytes of data payload: big-endian sensor data
         sensor_data = struct.pack(">HHHH",         # Big-endian u16 values at offset 8-15
@@ -155,7 +178,9 @@ class ActuatorEmulator:
                                  torque_scaled & 0xFFFF,
                                  temp_scaled & 0xFFFF)
         
-        return header + sensor_data
+        result = sensor_data
+        self.log(f"[Actuator {self.actuator_id}] Sending data: {result.hex()} (len={len(result)})")
+        return result
 
     def handle(self, bus, can_id: int, dlc: int, data: bytes):
         mux = mux_from_can_id(can_id)
@@ -175,6 +200,7 @@ class ActuatorEmulator:
         elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
             resp_can_id = make_response_can_id(can_id, 0x02, self.actuator_id)
             data_bytes = self.get_feedback_data()
+            self.log(f"[Actuator {self.actuator_id}] Feedback response: CAN_ID=0x{resp_can_id:08X}")
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -64,16 +64,81 @@ def make_response_can_id(request_can_id: int, resp_mux: int) -> int:
     return lower | top | 0x80000000
 
 
-class CanMotorEmulator:
-    def __init__(self, iface: str, actuator_id: int, host_id: int, periodic: float = 0.0, dry_run=False, verbose=False):
-        self.iface = iface
+class ActuatorEmulator:
+    def __init__(self, actuator_id: int, host_id: int = 1, verbose: bool = False):
         self.actuator_id = actuator_id
         self.host_id = host_id
-        self.periodic = periodic
+        self.verbose = verbose
+
+    def log(self, *a, **kw):
+        if self.verbose:
+            print(*a, **kw)
+
+    def handle(self, bus, can_id: int, dlc: int, data: bytes):
+        mux = mux_from_can_id(can_id)
+        req_act_id = actuator_id_from_can_id(can_id)
+        self.log(f"[{bus.iface}] REQ can_id=0x{can_id:08X} mux=0x{mux:02X} act={req_act_id} dlc={dlc} data={data.hex()}")
+
+        # Only respond for requests targeting this actuator or broadcast
+        if req_act_id not in (self.actuator_id, 0xFF):
+            return
+
+        if mux == 0x00:  # ObtainIdRequest -> ObtainIdResponse
+            resp_can_id = make_response_can_id(can_id, 0x00)
+            mcu_uid = (0xDEADBEEFCAF00000 | (self.actuator_id & 0xFF)) & 0xFFFFFFFFFFFFFFFF
+            data_bytes = mcu_uid.to_bytes(8, "little")
+            bus.send(resp_can_id, data_bytes)
+
+        elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
+            resp_can_id = make_response_can_id(can_id, 0x02)
+            angle = 0
+            vel = 0
+            torque = 0
+            temp = int(25.0 * 10)
+            data_bytes = struct.pack(
+                ">HHHH",
+                angle & 0xFFFF,
+                vel & 0xFFFF,
+                torque & 0xFFFF,
+                temp & 0xFFFF,
+            )
+            bus.send(resp_can_id, data_bytes)
+
+        elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse
+            resp_can_id = make_response_can_id(can_id, 0x11)
+            if len(data) >= 2:
+                index = int.from_bytes(data[0:2], "little")
+            else:
+                index = 0
+            data_bytes = struct.pack("<HHI", index & 0xFFFF, 0, 0)
+            bus.send(resp_can_id, data_bytes)
+
+        elif mux == 0x03:  # MotorEnableRequest -> reply with feedback
+            resp_can_id = make_response_can_id(can_id, 0x02)
+            temp = int(25.0 * 10)
+            data_bytes = struct.pack(
+                ">HHHH",
+                0,
+                0,
+                0,
+                temp & 0xFFFF,
+            )
+            bus.send(resp_can_id, data_bytes)
+
+        else:
+            self.log(f"[{bus.iface}] no handler for mux=0x{mux:02X}")
+
+
+class BusEmulator:
+    def __init__(self, iface: str, actuators: list, host_id: int = 1, dry_run: bool = False, verbose: bool = False, periodic: float = 0.0):
+        self.iface = iface
         self.dry_run = dry_run
         self.verbose = verbose
+        self.host_id = host_id
+        self.periodic = periodic
         self.sock = None
         self._stop = False
+        self.actuators = {a: ActuatorEmulator(a, host_id=host_id, verbose=verbose) for a in actuators}
 
     def log(self, *a, **kw):
         if self.verbose:
@@ -81,14 +146,13 @@ class CanMotorEmulator:
 
     def open(self):
         if self.dry_run:
-            self.log("dry-run: not opening socket")
+            self.log(f"[{self.iface}] dry-run: not opening socket")
             return
-        # AF_CAN raw socket
         s = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
-        # bind to interface
+        self.log(f"[{self.iface}] opening socket")
         s.bind((self.iface,))
         self.sock = s
-        self.log(f"bound to {self.iface}")
+        self.log(f"[{self.iface}] bound")
 
     def close(self):
         self._stop = True
@@ -98,70 +162,26 @@ class CanMotorEmulator:
     def send(self, can_id: int, data: bytes):
         frame = pack_frame(can_id, 8, data)
         if self.dry_run:
-            self.log("DRY SEND -> can_id=0x{:08X} data={}".format(can_id, data.hex()))
+            self.log(f"[{self.iface}] DRY SEND -> can_id=0x{can_id:08X} data={data.hex()}")
             return
-        self.sock.send(frame)
-        self.log("SENT -> can_id=0x{:08X} data={}".format(can_id, data.hex()))
+        try:
+            self.sock.send(frame)
+            self.log(f"[{self.iface}] SENT -> can_id=0x{can_id:08X} data={data.hex()}")
+        except OSError as e:
+            self.log(f"[{self.iface}] send error: {e}")
 
-    def handle_request(self, can_id: int, dlc: int, data: bytes):
-        mux = mux_from_can_id(can_id)
-        req_act_id = actuator_id_from_can_id(can_id)
-        self.log(f"REQ can_id=0x{can_id:08X} mux=0x{mux:02X} act={req_act_id} dlc={dlc} data={data.hex()}")
-
-        # Only respond for requests targeting our actuator id (or broadcast 0xFF)
-        if req_act_id not in (self.actuator_id, 0xFF):
-            self.log(f"ignoring request for actuator {req_act_id}")
-            return
-
-        if mux == 0x00:  # ObtainIdRequest -> ObtainIdResponse
-            resp_can_id = make_response_can_id(can_id, 0x00)
-            # mcu_uid: 8 bytes, create deterministic-ish value
-            mcu_uid = (0xDEADBEEFCAF00000 | (self.actuator_id & 0xFF)) & 0xFFFFFFFFFFFFFFFF
-            data_bytes = mcu_uid.to_bytes(8, "little")
-            self.send(resp_can_id, data_bytes)
-
-        elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
-            resp_can_id = make_response_can_id(can_id, 0x02)
-            # angle_scale_be, angular_vel_scale_be, torque_be, temp_be each u16 (big-endian)
-            # Provide neutral values: angle=0, vel=0, torque=0, temp=250 => 25.0C
-            angle = 0
-            vel = 0
-            torque = 0
-            temp = int(25.0 * 10)  # protocol uses temp*10
-            data_bytes = struct.pack(
-                ">HHHH",  # big-endian u16 fields
-                angle & 0xFFFF,
-                vel & 0xFFFF,
-                torque & 0xFFFF,
-                temp & 0xFFFF,
-            )
-            self.send(resp_can_id, data_bytes)
-
-        elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse
-            resp_can_id = make_response_can_id(can_id, 0x11)
-            # echo index (first two bytes of data are index in request little-endian per request impl)
-            if len(data) >= 2:
-                index = int.from_bytes(data[0:2], "little")
-            else:
-                index = 0
-            # Build response data: index(u16), res1(u16)=0, value(u32)=0
-            data_bytes = struct.pack("<HHI", index & 0xFFFF, 0, 0)
-            self.send(resp_can_id, data_bytes)
-
-        elif mux == 0x03:  # MotorEnableRequest -> reply with feedback to indicate enabled
-            resp_can_id = make_response_can_id(can_id, 0x02)
-            temp = int(25.0 * 10)
-            data_bytes = struct.pack(
-                ">HHHH",
-                0,
-                0,
-                0,
-                temp & 0xFFFF,
-            )
-            self.send(resp_can_id, data_bytes)
-
+    def dispatch(self, can_id: int, dlc: int, data: bytes):
+        # route to matching actuator(s); if target is 0xFF broadcast to all
+        target = actuator_id_from_can_id(can_id)
+        if target == 0xFF:
+            for a in self.actuators.values():
+                a.handle(self, can_id, dlc, data)
         else:
-            self.log(f"no handler for mux=0x{mux:02X}")
+            act = self.actuators.get(target)
+            if act:
+                act.handle(self, can_id, dlc, data)
+            else:
+                self.log(f"[{self.iface}] no emulator for actuator {target}")
 
     def reader_loop(self):
         while not self._stop:
@@ -171,62 +191,84 @@ class CanMotorEmulator:
                     continue
                 buf = self.sock.recv(FRAME_SIZE)
                 if len(buf) < FRAME_SIZE:
-                    self.log("short read: ", len(buf))
+                    self.log(f"[{self.iface}] short read: {len(buf)}")
                     continue
                 can_id, dlc, data = unpack_frame(buf)
-                self.handle_request(can_id, dlc, data)
+                self.dispatch(can_id, dlc, data)
             except OSError as e:
-                self.log("socket error:", e)
+                self.log(f"[{self.iface}] socket error: {e}")
                 break
 
-    def periodic_feedback_loop(self):
-        # Periodically broadcast feedback frames for our actuator id
+    def periodic_loop(self):
         if self.periodic <= 0:
             return
         while not self._stop:
-            # Build a fake feedback frame
-            # Build a can_id: put actuator id in bits 15-8 and mux 0x02 in top byte, set EFF
-            can_id = ((0x02 & 0x1F) << 24) | ((self.actuator_id & 0xFF) << 8) | 0x80000000
-            temp = int(25.0 * 10)
-            data_bytes = struct.pack(
-                ">HHHH",
-                0,
-                0,
-                0,
-                temp & 0xFFFF,
-            )
-            self.send(can_id, data_bytes)
+            for aid in list(self.actuators.keys()):
+                can_id = ((0x02 & 0x1F) << 24) | ((aid & 0xFF) << 8) | 0x80000000
+                temp = int(25.0 * 10)
+                data_bytes = struct.pack(
+                    ">HHHH",
+                    0,
+                    0,
+                    0,
+                    temp & 0xFFFF,
+                )
+                self.send(can_id, data_bytes)
             time.sleep(1.0 / self.periodic)
 
-    def run(self):
+    def start(self):
         self.open()
         rt = threading.Thread(target=self.reader_loop, daemon=True)
         rt.start()
         pt = None
         if self.periodic > 0:
-            pt = threading.Thread(target=self.periodic_feedback_loop, daemon=True)
+            pt = threading.Thread(target=self.periodic_loop, daemon=True)
             pt.start()
-
-        try:
-            while True:
-                time.sleep(0.2)
-        except KeyboardInterrupt:
-            self.log("stopping")
-            self.close()
+        return rt
 
 
 def main():
     p = argparse.ArgumentParser(description="CAN motor emulator (SocketCAN)")
-    p.add_argument("--iface", default=os.environ.get("CAN_IFACE", "vcan0"), help="CAN interface (default vcan0)")
-    p.add_argument("--actuator-id", type=int, default=1, help="Actuator CAN ID (0-255)")
+    p.add_argument("--iface", default=None, help="CAN interface (if provided, run a single bus)")
+    p.add_argument("--actuator-id", type=int, default=None, help="Actuator CAN ID (0-255) (if provided, run a single bus)")
     p.add_argument("--host-id", type=int, default=1, help="Host ID to emulate")
     p.add_argument("--periodic", type=float, default=0.0, help="Periodic feedback rate (Hz). 0 = disabled")
     p.add_argument("--dry-run", action="store_true", help="Don't open socket; just print actions")
     p.add_argument("--verbose", "-v", action="store_true")
     args = p.parse_args()
 
-    emu = CanMotorEmulator(args.iface, args.actuator_id, args.host_id, args.periodic, args.dry_run, args.verbose)
-    emu.run()
+    # If user provided a single iface/actuator, run a single bus
+    if args.iface and args.actuator_id is not None:
+        bus = BusEmulator(args.iface, [args.actuator_id], host_id=args.host_id, dry_run=args.dry_run, verbose=args.verbose, periodic=args.periodic)
+        bus.start()
+        try:
+            while True:
+                time.sleep(0.2)
+        except KeyboardInterrupt:
+            bus.close()
+        sys.exit(0)
+
+    # Default behaviour: launch two buses for development convenience
+    # can0: actuators 11-16, can1: actuators 21-26
+    default_buses = [
+        ("can0", list(range(11, 17))),
+        ("can1", list(range(21, 27))),
+    ]
+
+    threads = []
+    buses = []
+    for iface, acts in default_buses:
+        b = BusEmulator(iface, acts, host_id=args.host_id, dry_run=args.dry_run, verbose=args.verbose, periodic=args.periodic)
+        buses.append(b)
+        t = b.start()
+        threads.append(t)
+
+    try:
+        while True:
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        for b in buses:
+            b.close()
 
 
 if __name__ == "__main__":

--- a/scripts/can_motor_emulator.py
+++ b/scripts/can_motor_emulator.py
@@ -33,6 +33,15 @@ FRAME_FMT = "<I4B8s"  # little-endian: u32, 4 x u8, 8 bytes
 FRAME_SIZE = struct.calcsize(FRAME_FMT)
 
 
+# pub struct CanFrame {
+#     pub can_id: u32,
+#     pub len: u8,
+#     pub pad: u8,
+#     pub res0: u8,
+#     pub len8_dlc: u8,
+#     pub can_data: [u8; CAN_MAX_DLEN],
+# }
+
 def pack_frame(can_id: int, dlc: int, data: bytes) -> bytes:
     data = (data or b"")[:8]
     data = data.ljust(8, b"\x00")
@@ -56,12 +65,16 @@ def actuator_id_from_can_id(can_id: int) -> int:
     return can_id & 0xFF
 
 
-def make_response_can_id(request_can_id: int, resp_mux: int) -> int:
-    # Build response can_id: preserve lower 24 bits, set mux in top byte
-    # No EFF flag needed - the real responses don't use it
-    lower = request_can_id & 0x00FFFFFF
-    top = (resp_mux & 0x1F) << 24
-    return lower | top
+def make_response_can_id(request_can_id: int, resp_mux: int, actuator_id: int) -> int:
+    # Build response can_id that will be interpreted as the first 4 bytes of FeedbackResponse
+    # FeedbackResponse layout: host_id(0) + actuator_can_id(1) + fault_flags(2) + mux(3)
+    # Pack these into a u32 CAN ID in little-endian format
+    host_id = 0xFD  # Standard host ID used by firmware  
+    fault_flags = 0  # No faults
+    
+    # Pack as little-endian u32: [host_id, actuator_id, fault_flags, mux]
+    response_can_id = (host_id & 0xFF) | ((actuator_id & 0xFF) << 8) | ((fault_flags & 0xFF) << 16) | ((resp_mux & 0xFF) << 24)
+    return response_can_id
 
 
 class ActuatorEmulator:
@@ -104,7 +117,7 @@ class ActuatorEmulator:
         self.log(f"[Actuator {self.actuator_id}] Updated position: {self.position:.3f} rad, velocity: {self.velocity:.3f} rad/s")
 
     def get_feedback_data(self):
-        """Generate feedback response data"""
+        """Generate feedback response data - sensor data only (8 bytes)"""
         # Convert physical values back to scaled format for feedback
         # Using typical ranges
         ANGLE_RANGE = 4.0 * 3.14159265359
@@ -123,11 +136,26 @@ class ActuatorEmulator:
         torque_scaled = max(0, min(65535, torque_scaled))
         temp_scaled = max(0, min(65535, temp_scaled))
         
-        return struct.pack(">HHHH", 
-                          angle_scaled & 0xFFFF,
-                          vel_scaled & 0xFFFF, 
-                          torque_scaled & 0xFFFF,
-                          temp_scaled & 0xFFFF)
+        # The CAN frame structure when cast to FeedbackResponse:
+        # Bytes 0-3: CAN ID contains [host_id, actuator_id, fault_flags, mux] 
+        # Bytes 4-7: [len, pad, res0, len8_dlc] - these will be the first 4 bytes of data
+        # Bytes 8-15: sensor data - these will be the last 8 bytes of data
+        
+        # First 4 bytes of data payload: [len, pad, res0, len8_dlc]
+        header = struct.pack("BBBB", 
+                           8,      # len at offset 4
+                           0,      # pad at offset 5
+                           0,      # res0 at offset 6  
+                           0)      # len8_dlc at offset 7
+        
+        # Last 8 bytes of data payload: big-endian sensor data
+        sensor_data = struct.pack(">HHHH",         # Big-endian u16 values at offset 8-15
+                                 angle_scaled & 0xFFFF,
+                                 vel_scaled & 0xFFFF, 
+                                 torque_scaled & 0xFFFF,
+                                 temp_scaled & 0xFFFF)
+        
+        return header + sensor_data
 
     def handle(self, bus, can_id: int, dlc: int, data: bytes):
         mux = mux_from_can_id(can_id)
@@ -139,18 +167,18 @@ class ActuatorEmulator:
             return
 
         if mux == 0x00:  # ObtainIdRequest -> ObtainIdResponse
-            resp_can_id = make_response_can_id(can_id, 0x00)
+            resp_can_id = make_response_can_id(can_id, 0x00, self.actuator_id)
             mcu_uid = (0xDEADBEEFCAF00000 | (self.actuator_id & 0xFF)) & 0xFFFFFFFFFFFFFFFF
             data_bytes = mcu_uid.to_bytes(8, "little")
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x02:  # FeedbackRequest -> FeedbackResponse
-            resp_can_id = make_response_can_id(can_id, 0x02)
+            resp_can_id = make_response_can_id(can_id, 0x02, self.actuator_id)
             data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x11:  # ReadParamRequest -> ReadParamResponse
-            resp_can_id = make_response_can_id(can_id, 0x11)
+            resp_can_id = make_response_can_id(can_id, 0x11, self.actuator_id)
             if len(data) >= 2:
                 index = int.from_bytes(data[0:2], "little")
             else:
@@ -160,12 +188,12 @@ class ActuatorEmulator:
 
         elif mux == 0x01:  # ControlCommandRequest -> reply with feedback
             self.decode_control_command(data)
-            resp_can_id = make_response_can_id(can_id, 0x02)
+            resp_can_id = make_response_can_id(can_id, 0x02, self.actuator_id)
             data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 
         elif mux == 0x03:  # MotorEnableRequest -> reply with feedback
-            resp_can_id = make_response_can_id(can_id, 0x02)
+            resp_can_id = make_response_can_id(can_id, 0x02, self.actuator_id)
             data_bytes = self.get_feedback_data()
             bus.send(resp_can_id, data_bytes)
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,5 @@
+./start.sh can0
+./start.sh can1
+python3 can_motor_emulator.py
+./teardown.sh can0
+./teardown.sh can1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: scripts/start.sh [iface]
+# Creates and brings up a virtual CAN interface (vcan) if it doesn't exist.
+# Default iface: vcan0 or $CAN_IFACE env var.
+
+IFACE="${1:-${CAN_IFACE:-vcan0}}"
+
+echo "[start.sh] target interface: $IFACE"
+
+if ip link show "$IFACE" >/dev/null 2>&1; then
+    echo "[start.sh] interface '$IFACE' already exists"
+    ip -details link show "$IFACE" || true
+    exit 0
+fi
+
+echo "[start.sh] creating vcan module and interface $IFACE (requires sudo)"
+sudo modprobe vcan
+sudo ip link add dev "$IFACE" type vcan
+sudo ip link set up "$IFACE"
+
+echo "[start.sh] created and brought up $IFACE"
+echo "Now run your emulator: python3 scripts/can_motor_emulator.py --iface $IFACE --actuator-id <id>"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: scripts/teardown.sh [iface]
+# Removes the virtual CAN interface created by start.sh. Defaults to vcan0 or $CAN_IFACE
+
+IFACE="${1:-${CAN_IFACE:-vcan0}}"
+
+echo "[teardown.sh] target interface: $IFACE"
+
+if ! ip link show "$IFACE" >/dev/null 2>&1; then
+    echo "[teardown.sh] interface '$IFACE' does not exist; nothing to do"
+    exit 0
+fi
+
+echo "[teardown.sh] bringing down and deleting $IFACE (requires sudo)"
+sudo ip link set down "$IFACE" || true
+sudo ip link delete "$IFACE" type vcan || sudo ip link delete "$IFACE" || true
+
+echo "[teardown.sh] removed $IFACE"

--- a/scripts/usb/README.md
+++ b/scripts/usb/README.md
@@ -8,7 +8,7 @@ Files:
 Quick start:
 1. Ensure socat and python3 are installed on your system.
 2. Run: ./scripts/usb/start.sh
-3. The script will print the firmware PTY path (e.g. /tmp/imu_firmware). Point your firmware to that path (or symlink it to /dev/ttyUSB0 as root).
+3. The script will print the firmware PTY path (e.g. /tmp/imu_emulator_in). Point your firmware to that path (or symlink it to /dev/ttyUSB0 as root).
 
 Example: run the emulator at 100Hz with a custom quaternion:
 

--- a/scripts/usb/README.md
+++ b/scripts/usb/README.md
@@ -1,0 +1,19 @@
+This folder contains a simple USB/serial IMU emulator that uses socat to create a PTY pair
+and a small Python script to write Hiwonder IMU frames into the emulator side.
+
+Files:
+- start.sh    : creates a PTY pair using socat and runs imu_emulator.py bound to the emulator PTY
+- imu_emulator.py : Python script that writes 11-byte Hiwonder-format quaternion frames
+
+Quick start:
+1. Ensure socat and python3 are installed on your system.
+2. Run: ./scripts/usb/start.sh
+3. The script will print the firmware PTY path (e.g. /tmp/imu_firmware). Point your firmware to that path (or symlink it to /dev/ttyUSB0 as root).
+
+Example: run the emulator at 100Hz with a custom quaternion:
+
+./scripts/usb/start.sh --rate 100 --quat 1 0 0 0
+
+Notes:
+- This approach uses PTYs and is not a full USB gadget; it's sufficient for testing serial-level IMU behavior.
+- If you need true USB-level emulation, you can use Linux USB gadget/dummy_hcd; contact me if you want a script for that.

--- a/scripts/usb/imu_emulator.py
+++ b/scripts/usb/imu_emulator.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Simple IMU emulator that writes Hiwonder-format frames to a serial PTY.
+
+It writes 11-byte frames: [0]=0x55, [1]=frame_type (0x59 quaternion), [2..9]=payload (8 bytes), [10]=checksum(sum of first 10 bytes & 0xff).
+
+By default it emits Quaternion frames (FrameType::Quaternion = 0x59) at a configurable rate.
+
+This script avoids external deps; it opens the character device and writes raw bytes.
+"""
+
+import argparse
+import os
+import sys
+import time
+import struct
+
+FRAME_SIZE = 11
+START = 0x55
+FRAME_QUAT = 0x59  # Quaternion
+
+
+def make_quat_frame(w_raw=16384, x_raw=0, y_raw=0, z_raw=0):
+    # Hiwonder payload layout for Quaternion uses four i16 values in little-endian, placed in data[0..7]:
+    # data[0..1] = w (low, high), data[2..3] = x, data[4..5] = y, data[6..7] = z
+    payload = struct.pack('<hhhh', w_raw, x_raw, y_raw, z_raw)
+    assert len(payload) == 8
+    head = bytes([START, FRAME_QUAT])
+    buf0_9 = head + payload
+    checksum = sum(buf0_9) & 0xFF
+    frame = buf0_9 + bytes([checksum])
+    assert len(frame) == FRAME_SIZE
+    return frame
+
+
+def open_device(path):
+    # Open the device for binary write without buffering
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_NOCTTY)
+        return fd
+    except OSError as e:
+        print(f"Failed to open {path}: {e}", file=sys.stderr)
+        raise
+
+
+def main():
+    p = argparse.ArgumentParser(description="HIWONDER IMU emulator -> write Hiwonder frames to a PTY/serial device")
+    p.add_argument('--port', '-p', required=True, help='Emulator side PTY path (this script writes to it)')
+    p.add_argument('--rate', '-r', type=float, default=50.0, help='Frame rate (Hz)')
+    p.add_argument('--debug', action='store_true')
+    p.add_argument('--quat', nargs=4, type=float, help='Quaternion as floats (w x y z), normalized-ish, will be scaled to int16')
+    args = p.parse_args()
+
+    interval = 1.0 / max(0.1, args.rate)
+
+    if args.quat:
+        # convert floats -1..1 -> raw int16 range roughly [-32768,32767]
+        q = args.quat
+        def to_raw(v):
+            return int(max(-32768, min(32767, round(v * 32767))))
+        w_raw, x_raw, y_raw, z_raw = map(to_raw, q)
+    else:
+        # default quaternion w=0.5 -> raw ~16384
+        w_raw, x_raw, y_raw, z_raw = 16384, 0, 0, 0
+
+    try:
+        fd = open_device(args.port)
+    except Exception:
+        sys.exit(1)
+
+    print(f"Writing Hiwonder quaternion frames to {args.port} @ {args.rate}Hz (interval {interval}s)")
+
+    try:
+        while True:
+            frame = make_quat_frame(w_raw, x_raw, y_raw, z_raw)
+            try:
+                os.write(fd, frame)
+            except BrokenPipeError:
+                print("Peer closed PTY (broken pipe). Exiting.", file=sys.stderr)
+                break
+            if args.debug:
+                print(frame.hex())
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/usb/imu_emulator.py
+++ b/scripts/usb/imu_emulator.py
@@ -69,11 +69,18 @@ def main():
 
     print(f"Writing Hiwonder quaternion frames to {args.port} @ {args.rate}Hz (interval {interval}s)")
 
+    spinner = ['|', '/', '-', '\\']
+    spinner_index = 0
+
     try:
         while True:
             frame = make_quat_frame(w_raw, x_raw, y_raw, z_raw)
             try:
                 os.write(fd, frame)
+                # print loading spinner
+                print(f"\r{spinner_index} Sent frame: {frame.hex()}", end='', flush=True)
+                spinner_index+=1
+
             except BrokenPipeError:
                 print("Peer closed PTY (broken pipe). Exiting.", file=sys.stderr)
                 break

--- a/scripts/usb/start.sh
+++ b/scripts/usb/start.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a PTY pair with socat and run the Python IMU emulator bound to one end.
+# Firmware should open the "firmware" PTY. The emulator will open the "emulator" PTY
+# and write Hiwonder-formatted 11-byte frames.
+
+EMULATOR_PTY=${EMULATOR_PTY:-/tmp/imu_emulator}
+FIRMWARE_PTY=${FIRMWARE_PTY:-/tmp/imu_firmware}
+PYTHON="$(command -v python3 || true)"
+if [ -z "$PYTHON" ]; then
+  echo "python3 not found in PATH"
+  exit 1
+fi
+
+# Start socat to create a PTY pair (runs until killed). -d -d prints debug info to stderr.
+# link= sets a stable path for convenience.
+
+socat -d -d pty,raw,echo=0,link="$FIRMWARE_PTY" pty,raw,echo=0,link="$EMULATOR_PTY" &
+SOCAT_PID=$!
+
+trap 'echo "shutting down..."; kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true' EXIT INT TERM
+
+# Wait briefly for socat to create links
+sleep 0.2
+
+if [ ! -e "$FIRMWARE_PTY" ] || [ ! -e "$EMULATOR_PTY" ]; then
+  echo "PTYs not created yet, waiting a moment..."
+  sleep 0.5
+fi
+
+echo "PTY pair created: firmware -> $FIRMWARE_PTY  emulator -> $EMULATOR_PTY"
+echo "Run your firmware against: $FIRMWARE_PTY"
+echo "(Run as root to symlink to /dev/ttyUSB0 if you really need that: sudo ln -sf $FIRMWARE_PTY /dev/ttyUSB0)"
+
+# Pass through any additional args to the Python emulator (e.g. --rate)
+"$PYTHON" "$(dirname "$0")/imu_emulator.py" --port "$EMULATOR_PTY" "$@"
+
+# end trap will kill socat

--- a/scripts/usb/start.sh
+++ b/scripts/usb/start.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create a PTY pair with socat and run the Python IMU emulator bound to one end.
-# Firmware should open the "firmware" PTY. The emulator will open the "emulator" PTY
-# and write Hiwonder-formatted 11-byte frames.
+# Create a null modem emulation using socat that's compatible with tokio_serial
+# This approach creates a more realistic serial device emulation
 
 EMULATOR_PTY=${EMULATOR_PTY:-/tmp/imu_emulator_out}
 FIRMWARE_PTY=${FIRMWARE_PTY:-/tmp/imu_emulator_in}
@@ -13,25 +12,36 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-# Start socat to create a PTY pair (runs until killed). -d -d prints debug info to stderr.
-# link= sets a stable path for convenience.
-
-socat -d -d pty,raw,echo=0,link="$FIRMWARE_PTY",mode=0666 pty,raw,echo=0,link="$EMULATOR_PTY",mode=0666 &
+# Use a simpler, more reliable socat command that creates proper TTY devices
+# Remove complex options that might confuse tokio_serial
+socat pty,link="$FIRMWARE_PTY",raw,echo=0 pty,link="$EMULATOR_PTY",raw,echo=0 &
 SOCAT_PID=$!
 
 trap 'echo "shutting down..."; kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true' EXIT INT TERM
 
 # Wait briefly for socat to create links
-sleep 0.2
+sleep 0.5
+
+# Wait up to 5 seconds for PTYs to be created
+WAIT_COUNT=0
+while [ $WAIT_COUNT -lt 50 ]; do
+    if [ -e "$FIRMWARE_PTY" ] && [ -e "$EMULATOR_PTY" ]; then
+        break
+    fi
+    echo "Waiting for PTYs to be created... ($((WAIT_COUNT + 1))/50)"
+    sleep 0.1
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+done
 
 if [ ! -e "$FIRMWARE_PTY" ] || [ ! -e "$EMULATOR_PTY" ]; then
-  echo "PTYs not created yet, waiting a moment..."
-  sleep 0.5
+  echo "PTYs not created after waiting 5 seconds, aborting..."
+  exit 1
 fi
 
 echo "PTY pair created: firmware -> $FIRMWARE_PTY  emulator -> $EMULATOR_PTY"
 echo "Run your firmware against: $FIRMWARE_PTY"
-echo "(Run as root to symlink to /dev/ttyUSB0 if you really need that: sudo ln -sf $FIRMWARE_PTY /dev/ttyUSB0)"
+echo "(Set IMU_DEV environment variable: export IMU_DEV=$FIRMWARE_PTY)"
+echo "(Or run as root to symlink to /dev/ttyUSB0: sudo ln -sf $FIRMWARE_PTY /dev/ttyUSB0)"
 
 # Pass through any additional args to the Python emulator (e.g. --rate)
 "$PYTHON" "$(dirname "$0")/imu_emulator.py" --port "$EMULATOR_PTY" "$@"

--- a/scripts/usb/start.sh
+++ b/scripts/usb/start.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Firmware should open the "firmware" PTY. The emulator will open the "emulator" PTY
 # and write Hiwonder-formatted 11-byte frames.
 
-EMULATOR_PTY=${EMULATOR_PTY:-/tmp/imu_emulator}
-FIRMWARE_PTY=${FIRMWARE_PTY:-/tmp/imu_firmware}
+EMULATOR_PTY=${EMULATOR_PTY:-/tmp/imu_emulator_out}
+FIRMWARE_PTY=${FIRMWARE_PTY:-/tmp/imu_emulator_in}
 PYTHON="$(command -v python3 || true)"
 if [ -z "$PYTHON" ]; then
   echo "python3 not found in PATH"

--- a/scripts/usb/start.sh
+++ b/scripts/usb/start.sh
@@ -16,7 +16,7 @@ fi
 # Start socat to create a PTY pair (runs until killed). -d -d prints debug info to stderr.
 # link= sets a stable path for convenience.
 
-socat -d -d pty,raw,echo=0,link="$FIRMWARE_PTY" pty,raw,echo=0,link="$EMULATOR_PTY" &
+socat -d -d pty,raw,echo=0,link="$FIRMWARE_PTY",mode=0666 pty,raw,echo=0,link="$EMULATOR_PTY",mode=0666 &
 SOCAT_PID=$!
 
 trap 'echo "shutting down..."; kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true' EXIT INT TERM

--- a/src/imu.rs
+++ b/src/imu.rs
@@ -293,9 +293,11 @@ impl Default for ImuManager {
 
 impl ImuManager {
     pub fn new() -> Self {
+        let dev = std::env::var("IMU_DEV").unwrap_or_else(|_| "/dev/ttyUSB0".to_string());
+        info!("Using IMU device path: {}", dev);
         Self {
             state: Some(StateStore::Reset(Reset {
-                shared_state: Box::pin(Store::new("/dev/ttyUSB0")),
+                shared_state: Box::pin(Store::new(&dev)),
             })),
             target: None,
             pending_fut: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,10 +114,9 @@ fn main() {
     // Prepare tracing to forward to our thread
     let forward_layer = HeaplessForwardLayer { tx }.with_filter(trace_only_filter);
 
-    // Add stdout layer for INFO and above
-    let stdout_layer = fmt::layer().with_target(true).with_level(true).with_filter(
-        EnvFilter::from_default_env().add_directive("faux_rtos=info".parse().unwrap()),
-    );
+    let stdout_filter = EnvFilter::from_default_env();
+    
+    let stdout_layer = fmt::layer().with_target(true).with_level(true).with_filter(stdout_filter);
 
     let subscriber = tracing_subscriber::registry()
         .with(forward_layer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 pub mod hiwonder;
 pub mod typestate_serial;
+pub mod serial_device;
 
 pub mod actuator;
 pub mod actuator_manager;

--- a/src/robstride.rs
+++ b/src/robstride.rs
@@ -701,6 +701,7 @@ impl ActuatorCanClient {
             }
             ActuatorResponse::Feedback(resp) => {
                 debug!("Received Feedback response: {:?}", resp);
+                debug!("Raw feedback frame: {:02x?}", bytemuck::bytes_of(response));
                 if resp.actuator_can_id != self.actuator_can_id {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -712,11 +713,11 @@ impl ActuatorCanClient {
                 Ok(Some(self.update_from_feedback(&resp, response)))
             }
             ActuatorResponse::ReadParam(resp) => {
-                debug!("Received Feedback response: {:?}", resp);
+                debug!("Received ReadParam response: {:?}", resp);
                 if resp.actuator_can_id != self.actuator_can_id {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        "Feedback response does not match expected actuator CAN ID",
+                        "ReadParam response does not match expected actuator CAN ID",
                     ));
                 }
                 self.state = ActuatorClientState::Ready;

--- a/src/serial_device.rs
+++ b/src/serial_device.rs
@@ -1,0 +1,165 @@
+use std::io;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncReadExt, AsyncWriteExt};
+use tokio::fs::File;
+use tokio_serial::SerialPortBuilderExt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A wrapper that can handle both real serial devices and PTYs
+#[derive(Debug)]
+pub enum SerialDevice {
+    Serial(tokio_serial::SerialStream),
+    Pty(tokio::fs::File),
+}
+
+impl SerialDevice {
+    pub async fn open(path: &str, baud: u32) -> io::Result<Self> {
+        // First try to open as a real serial device
+        match tokio_serial::new(path, baud).open_native_async() {
+            Ok(serial) => {
+                tracing::info!("Opened {} as serial device", path);
+                Ok(SerialDevice::Serial(serial))
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                if error_msg.contains("Not a typewriter") || error_msg.contains("ENOTTY") {
+                    tracing::warn!("Device {} appears to be a PTY, opening as file", path);
+                    // Try to open as a PTY/file
+                    match tokio::fs::OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .open(path)
+                        .await
+                    {
+                        Ok(file) => {
+                            tracing::info!("Opened {} as PTY device", path);
+                            Ok(SerialDevice::Pty(file))
+                        }
+                        Err(file_err) => {
+                            tracing::error!("Failed to open {} as PTY: {}", path, file_err);
+                            Err(file_err)
+                        }
+                    }
+                } else {
+                    Err(e.into())
+                }
+            }
+        }
+    }
+
+    pub fn clear(&mut self, _buffer: tokio_serial::ClearBuffer) -> io::Result<()> {
+        match self {
+            SerialDevice::Serial(serial) => {
+                use tokio_serial::SerialPort;
+                serial.clear(_buffer).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            }
+            SerialDevice::Pty(_) => {
+                // PTYs don't need buffer clearing
+                tracing::debug!("Buffer clear ignored for PTY");
+                Ok(())
+            }
+        }
+    }
+
+    pub fn set_baud_rate(&mut self, baud: u32) -> io::Result<()> {
+        match self {
+            SerialDevice::Serial(serial) => {
+                use tokio_serial::SerialPort;
+                serial.set_baud_rate(baud).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            }
+            SerialDevice::Pty(_) => {
+                // PTYs don't have baud rates
+                tracing::debug!("Baud rate setting ignored for PTY");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        match self {
+            SerialDevice::Serial(serial) => {
+                serial.read_exact(buf).await?;
+                Ok(())
+            }
+            SerialDevice::Pty(file) => {
+                let mut total_read = 0;
+                while total_read < buf.len() {
+                    let n = file.read(&mut buf[total_read..]).await?;
+                    if n == 0 {
+                        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF while reading"));
+                    }
+                    total_read += n;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            SerialDevice::Serial(serial) => serial.read(buf).await,
+            SerialDevice::Pty(file) => file.read(buf).await,
+        }
+    }
+
+    pub fn try_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            SerialDevice::Serial(serial) => {
+                use tokio_serial::SerialPort;
+                serial.try_read(buf).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            }
+            SerialDevice::Pty(_file) => {
+                // For PTYs, try_read is not available on File
+                // We'll simulate it by returning WouldBlock for now
+                Err(io::Error::new(io::ErrorKind::WouldBlock, "try_read not supported on PTY"))
+            }
+        }
+    }
+
+    pub async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            SerialDevice::Serial(serial) => serial.write(buf).await,
+            SerialDevice::Pty(file) => file.write(buf).await,
+        }
+    }
+}
+
+impl AsyncRead for SerialDevice {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            SerialDevice::Serial(serial) => Pin::new(serial).poll_read(cx, buf),
+            SerialDevice::Pty(file) => Pin::new(file).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for SerialDevice {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.get_mut() {
+            SerialDevice::Serial(serial) => Pin::new(serial).poll_write(cx, buf),
+            SerialDevice::Pty(file) => Pin::new(file).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.get_mut() {
+            SerialDevice::Serial(serial) => Pin::new(serial).poll_flush(cx),
+            SerialDevice::Pty(file) => Pin::new(file).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.get_mut() {
+            SerialDevice::Serial(serial) => Pin::new(serial).poll_shutdown(cx),
+            SerialDevice::Pty(file) => Pin::new(file).poll_shutdown(cx),
+        }
+    }
+}

--- a/src/typestate_serial.rs
+++ b/src/typestate_serial.rs
@@ -6,6 +6,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
 use tracing::{error, info, warn};
+use crate::serial_device::SerialDevice;
 
 use futures::{Stream, StreamExt};
 use std::task::{Context, Poll};
@@ -36,7 +37,7 @@ pub enum SerialBaudRate {
 struct Store {
     devpath: String,
     baud: SerialBaudRate,
-    port: Option<SerialStream>,
+    port: Option<SerialDevice>,
 }
 
 impl Store {
@@ -72,13 +73,11 @@ impl State for Reset {
     fn transition_fut(mut self) -> impl std::future::Future<Output = StateTransitionResult> {
         async move {
             let ss = self.shared_state.as_mut().project();
-            let builder = tokio_serial::new(ss.devpath.as_str(), *ss.baud as u32);
-            match builder.open_native_async() {
-                Ok(port) => {
-                    {
-                        use tokio_serial::SerialPort;
-                        port.clear(tokio_serial::ClearBuffer::All);
-                    }
+            
+            // Use our custom SerialDevice that handles both real serial and PTYs
+            match SerialDevice::open(ss.devpath.as_str(), *ss.baud as u32).await {
+                Ok(mut port) => {
+                    port.clear(tokio_serial::ClearBuffer::All);
                     *ss.port = Some(port);
                     // Transition to the next state
                     StateTransitionResult {
@@ -88,12 +87,14 @@ impl State for Reset {
                         result: Ok(()),
                     }
                 }
-                Err(e) => StateTransitionResult {
-                    state: StateStore::Reset(Reset {
-                        shared_state: self.shared_state,
-                    }),
-                    result: Err(e.into()),
-                },
+                Err(e) => {
+                    StateTransitionResult {
+                        state: StateStore::Reset(Reset {
+                            shared_state: self.shared_state,
+                        }),
+                        result: Err(e),
+                    }
+                }
             }
         }
     }
@@ -114,7 +115,7 @@ impl State for Operate {
 }
 
 impl Operate {
-    pub async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let ss = self.shared_state.as_mut().project();
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
@@ -126,50 +127,35 @@ impl Operate {
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
         *ss.baud = baud;
-        {
-            use tokio_serial::SerialPort;
-            port.set_baud_rate(baud as u32).map_err(|e| e.into())
-        }
+        port.set_baud_rate(baud as u32)
     }
 
     pub fn try_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let ss = self.shared_state.as_mut().project();
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
-        {
-            use tokio_serial::SerialPort;
-            port.try_read(buf)
-        }
+        port.try_read(buf)
     }
 
     pub async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let ss = self.shared_state.as_mut().project();
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
-        {
-            use tokio_serial::SerialPort;
-            port.read(buf).await
-        }
+        port.read(buf).await
     }
 
     pub fn clear(&mut self, clear_buffer: tokio_serial::ClearBuffer) -> io::Result<()> {
         let ss = self.shared_state.as_mut().project();
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
-        {
-            use tokio_serial::SerialPort;
-            port.clear(clear_buffer).map_err(|e| e.into())
-        }
+        port.clear(clear_buffer)
     }
 
     pub async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let ss = self.shared_state.as_mut().project();
         // SAFETY: port must not None
         let port = ss.port.as_mut().unwrap();
-        {
-            use tokio_serial::SerialPort;
-            port.write(buf).await
-        }
+        port.write(buf).await
     }
 }
 
@@ -213,10 +199,7 @@ impl SerialPort {
         // SAFETY: we can unpin as the future is finished
         let unpinned = unsafe { Pin::get_unchecked_mut(shared_state.as_mut()) };
         unpinned.baud = baud;
-        {
-            use tokio_serial::SerialPort;
-            unpinned.port.as_mut().unwrap().set_baud_rate(baud as u32)?
-        }
+        unpinned.port.as_mut().unwrap().set_baud_rate(baud as u32)?;
 
         self.state = Some(StateStore::Operate(Operate { shared_state }));
         Ok(())


### PR DESCRIPTION
This lets us integration test the firmware locally without any hardware. To test, run `scripts/run.sh` and `scripts/usb/start.sh`, then `cargo run`